### PR TITLE
Interim work for using rules.csv style files for terraforming rules

### DIFF
--- a/.idea/csv-editor.xml
+++ b/.idea/csv-editor.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CsvFileAttributes">
+    <option name="attributeMap">
+      <map>
+        <entry key="/data/campaign/industries.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/data/campaign/rules.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+        <entry key="/data/config/LunaSettings.csv">
+          <value>
+            <Attribute>
+              <option name="separator" value="," />
+            </Attribute>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/src/data/campaign/econ/boggledTools.java
+++ b/src/data/campaign/econ/boggledTools.java
@@ -28,7 +28,6 @@ import com.fs.starfarer.campaign.CircularOrbit;
 import com.fs.starfarer.campaign.CircularOrbitPointDown;
 import com.fs.starfarer.campaign.CircularOrbitWithSpin;
 import com.fs.starfarer.loading.specs.PlanetSpec;
-import data.kaysaar.aotd.vok.scripts.research.AoTDMainResearchManager;
 import illustratedEntities.helper.ImageHandler;
 import illustratedEntities.helper.Settings;
 import illustratedEntities.helper.TextHandler;
@@ -446,9 +445,9 @@ public class boggledTools
     public static void refreshSupplyAndDemand(MarketAPI market) {
         //Refreshes supply and demand for each industry on the market
         List<Industry> industries = market.getIndustries();
-        for (int i = 0; i < industries.size(); i++) {
-            industries.get(i).doPreSaveCleanup();
-            industries.get(i).doPostSaveRestore();
+        for (Industry industry : industries) {
+            industry.doPreSaveCleanup();
+            industry.doPostSaveRestore();
         }
     }
 
@@ -459,12 +458,8 @@ public class boggledTools
 
     public static boolean gateInSystem(StarSystemAPI system)
     {
-        Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity.hasTag("gate"))
-            {
+        for (SectorEntityToken entity : system.getAllEntities()) {
+            if (entity.hasTag("gate")) {
                 return true;
             }
         }
@@ -473,9 +468,7 @@ public class boggledTools
     }
 
     public static boolean playerMarketInSystem(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
             if (entity.getMarket() != null && entity.getMarket().isPlayerOwned()) {
                 return true;
             }
@@ -489,13 +482,9 @@ public class boggledTools
         // Returns zero if there are no player markets in the system.
         // Counts markets where the player purchased governorship.
 
-        Iterator allPlayerMarkets = Misc.getPlayerMarkets(true).iterator();
         int largestMarketSize = 0;
-        while(allPlayerMarkets.hasNext())
-        {
-            MarketAPI market = (MarketAPI) allPlayerMarkets.next();
-            if(market.getStarSystem().equals(system) && market.getSize() > largestMarketSize)
-            {
+        for (MarketAPI market : Misc.getPlayerMarkets(true)) {
+            if (market.getStarSystem().equals(system) && market.getSize() > largestMarketSize) {
                 largestMarketSize = market.getSize();
             }
         }
@@ -514,18 +503,14 @@ public class boggledTools
         } else {
             ArrayList<SectorEntityToken> allPlayerMarketsInSystem = new ArrayList<SectorEntityToken>();
 
-            Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-            while (allEntitiesInSystem.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+            for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity.getMarket() != null && entity.getMarket().isPlayerOwned()) {
                     allPlayerMarketsInSystem.add(entity);
                 }
             }
 
             SectorEntityToken closestMarket = null;
-            Iterator checkDistancesOfPlayerMarkets = allPlayerMarketsInSystem.iterator();
-            while (checkDistancesOfPlayerMarkets.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) checkDistancesOfPlayerMarkets.next();
+            for (SectorEntityToken entity : allPlayerMarketsInSystem) {
                 if (closestMarket == null) {
                     closestMarket = entity;
                 } else if (getDistanceBetweenTokens(entity, playerFleet) < getDistanceBetweenTokens(closestMarket, playerFleet)) {
@@ -538,9 +523,7 @@ public class boggledTools
     }
 
     public static boolean gasGiantInSystem(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken planet = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken planet : playerFleet.getStarSystem().getAllEntities()) {
             if (planet instanceof PlanetAPI && ((PlanetAPI) planet).isGasGiant()) {
                 return true;
             }
@@ -555,18 +538,14 @@ public class boggledTools
         } else {
             ArrayList<SectorEntityToken> allGasGiantsInSystem = new ArrayList<SectorEntityToken>();
 
-            Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-            while (allEntitiesInSystem.hasNext()) {
-                SectorEntityToken planet = (SectorEntityToken) allEntitiesInSystem.next();
+            for (SectorEntityToken planet : playerFleet.getStarSystem().getAllEntities()) {
                 if (planet instanceof PlanetAPI && ((PlanetAPI) planet).isGasGiant()) {
                     allGasGiantsInSystem.add(planet);
                 }
             }
 
             SectorEntityToken closestGasGiant = null;
-            Iterator checkDistancesOfGasGiants = allGasGiantsInSystem.iterator();
-            while (checkDistancesOfGasGiants.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) checkDistancesOfGasGiants.next();
+            for (SectorEntityToken entity : allGasGiantsInSystem) {
                 if (closestGasGiant == null) {
                     closestGasGiant = entity;
                 } else if (getDistanceBetweenTokens(entity, playerFleet) < getDistanceBetweenTokens(closestGasGiant, playerFleet)) {
@@ -579,9 +558,7 @@ public class boggledTools
     }
 
     public static boolean colonizableStationInSystem(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
             if (entity.hasTag("station") && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
                 return true;
             }
@@ -596,18 +573,14 @@ public class boggledTools
         } else {
             ArrayList<SectorEntityToken> allColonizableStationsInSystem = new ArrayList<SectorEntityToken>();
 
-            Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-            while (allEntitiesInSystem.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+            for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity.hasTag("station") && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
                     allColonizableStationsInSystem.add(entity);
                 }
             }
 
             SectorEntityToken closestStation = null;
-            Iterator checkDistancesOfStations = allColonizableStationsInSystem.iterator();
-            while (checkDistancesOfStations.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) checkDistancesOfStations.next();
+            for (SectorEntityToken entity : allColonizableStationsInSystem) {
                 if (closestStation == null) {
                     closestStation = entity;
                 } else if (getDistanceBetweenTokens(entity, playerFleet) < getDistanceBetweenTokens(closestStation, playerFleet)) {
@@ -620,9 +593,7 @@ public class boggledTools
     }
 
     public static boolean stationInSystem(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
             if (entity.hasTag("station")) {
                 return true;
             }
@@ -637,19 +608,14 @@ public class boggledTools
         } else {
             ArrayList<SectorEntityToken> allStationsInSystem = new ArrayList<SectorEntityToken>();
 
-            Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-            while (allEntitiesInSystem.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                if (entity.hasTag("station"))
-                {
+            for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+                if (entity.hasTag("station")) {
                     allStationsInSystem.add(entity);
                 }
             }
 
             SectorEntityToken closestStation = null;
-            Iterator checkDistancesOfStations = allStationsInSystem.iterator();
-            while (checkDistancesOfStations.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) checkDistancesOfStations.next();
+            for (SectorEntityToken entity : allStationsInSystem) {
                 if (closestStation == null) {
                     closestStation = entity;
                 } else if (getDistanceBetweenTokens(entity, playerFleet) < getDistanceBetweenTokens(closestStation, playerFleet)) {
@@ -664,9 +630,7 @@ public class boggledTools
     public static ArrayList<String> getListOfFactionsWithMarketInSystem(StarSystemAPI system) {
         ArrayList<String> factionsWithMarketInSystem = new ArrayList<String>();
 
-        Iterator allMarkets = Global.getSector().getEconomy().getMarkets(system).iterator();
-        while (allMarkets.hasNext()) {
-            MarketAPI market = (MarketAPI) allMarkets.next();
+        for (MarketAPI market : Global.getSector().getEconomy().getMarkets(system)) {
             if (!factionsWithMarketInSystem.contains(market.getFactionId())) {
                 factionsWithMarketInSystem.add(market.getFactionId());
             }
@@ -678,14 +642,9 @@ public class boggledTools
     public static ArrayList<Integer> getCompanionListOfTotalMarketPopulation(StarSystemAPI system, ArrayList<String> factions) {
         ArrayList<Integer> totalFactionMarketSize = new ArrayList<Integer>();
         int buffer = 0;
-        Iterator allMarkets = null;
 
-        Iterator allFactionsWithMarketInSystem = factions.iterator();
-        while (allFactionsWithMarketInSystem.hasNext()) {
-            String faction = (String) allFactionsWithMarketInSystem.next();
-            allMarkets = Global.getSector().getEconomy().getMarkets(system).iterator();
-            while (allMarkets.hasNext()) {
-                MarketAPI market = (MarketAPI) allMarkets.next();
+        for (String faction : factions) {
+            for (MarketAPI market : Global.getSector().getEconomy().getMarkets(system)) {
                 if (market.getFactionId().equals(faction)) {
                     buffer = buffer + market.getSize();
                 }
@@ -699,9 +658,7 @@ public class boggledTools
     }
 
     public static boolean planetInSystem(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken planet = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken planet : playerFleet.getStarSystem().getAllEntities()) {
             if (planet instanceof PlanetAPI && !getPlanetType(((PlanetAPI) planet)).equals("star")) {
                 return true;
             }
@@ -720,18 +677,14 @@ public class boggledTools
         } else {
             ArrayList<SectorEntityToken> allPlanetsInSystem = new ArrayList<SectorEntityToken>();
 
-            Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-            while (allEntitiesInSystem.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+            for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity instanceof PlanetAPI && !getPlanetType(((PlanetAPI) entity)).equals("star")) {
                     allPlanetsInSystem.add(entity);
                 }
             }
 
             SectorEntityToken closestPlanet = null;
-            Iterator checkDistancesOfPlanets = allPlanetsInSystem.iterator();
-            while (checkDistancesOfPlanets.hasNext()) {
-                SectorEntityToken entity = (SectorEntityToken) checkDistancesOfPlanets.next();
+            for (SectorEntityToken entity : allPlanetsInSystem) {
                 if (closestPlanet == null) {
                     closestPlanet = entity;
                 } else if (getDistanceBetweenTokens(entity, playerFleet) < getDistanceBetweenTokens(closestPlanet, playerFleet)) {
@@ -784,30 +737,146 @@ public class boggledTools
 
         String planetType = planet.getTypeId();
 
-        if (planetType.equals("nebula_center_old") || planetType.equals("nebula_center_average") || planetType.equals("nebula_center_young") || planetType.equals("star_neutron") || planetType.equals("black_hole") || planetType.equals("star_yellow") || planetType.equals("star_white") || planetType.equals("star_blue_giant") || planetType.equals("star_blue_supergiant") || planetType.equals("star_orange") || planetType.equals("star_orange_giant") || planetType.equals("star_red_supergiant") || planetType.equals("star_red_giant") || planetType.equals("star_red_dwarf") || planetType.equals("star_browndwarf") || planetType.equals("US_star_blue_giant") || planetType.equals("US_star_yellow") || planetType.equals("US_star_orange") || planetType.equals("US_star_red_giant") || planetType.equals("US_star_white") || planetType.equals("US_star_browndwarf") || planetType.equals("SCY_star") || planetType.equals("SCY_companionStar") || planetType.equals("SCY_wormholeUnder") || planetType.equals("SCY_wormholeA") || planetType.equals("SCY_wormholeB") || planetType.equals("SCY_wormholeC") || planetType.equals("istl_sigmaworld") || planetType.equals("istl_dysonshell") || planetType.equals("vayra_star_blue") || planetType.equals("vayra_star_brown") || planetType.equals("vayra_star_yellow_white")) {
-            return "star";
-        } else if (planetType.equals("gas_giant") || planetType.equals("ice_giant") || planetType.equals("US_gas_giant") || planetType.equals("US_gas_giantB") || planetType.equals("fds_gas_giant") || planetType.equals("SCY_tartarus") || planetType.equals("galaxytigers_gas_giant")) {
-            return "gas_giant";
-        } else if (planetType.equals("barren") || planetType.equals("barren_castiron") || planetType.equals("barren2") || planetType.equals("barren3") || planetType.equals("barren_venuslike") || planetType.equals("rocky_metallic") || planetType.equals("rocky_unstable") || planetType.equals("rocky_ice") || planetType.equals("irradiated") || planetType.equals("barren-bombarded") || planetType.equals("US_acid") || planetType.equals("US_acidRain") || planetType.equals("US_acidWind") || planetType.equals("US_barrenA") || planetType.equals("US_barrenB") || planetType.equals("US_barrenC") || planetType.equals("US_barrenD") || planetType.equals("US_barrenE") || planetType.equals("US_barrenF") || planetType.equals("US_azure") || planetType.equals("US_burnt") || planetType.equals("US_artificial") || planetType.equals("haunted") || planetType.equals("hmi_crystalline") || planetType.equals("SCY_miningColony") || planetType.equals("SCY_burntPlanet") || planetType.equals("SCY_moon") || planetType.equals("SCY_redRock") || planetType.equals("rad_planet") || planetType.equals("ecumenopolis") || planetType.equals("nskr_ice_desert")) {
-            return "barren";
-        } else if (planetType.equals("toxic") || planetType.equals("toxic_cold") || planetType.equals("US_green") || planetType.equals("SCY_acid")) {
-            return "toxic";
-        } else if (planetType.equals("desert") || planetType.equals("desert1") || planetType.equals("arid") || planetType.equals("barren-desert") || planetType.equals("US_dust") || planetType.equals("US_desertA") || planetType.equals("US_desertB") || planetType.equals("US_desertC") || planetType.equals("US_red") || planetType.equals("US_redWind") || planetType.equals("US_lifelessArid") || planetType.equals("US_arid") || planetType.equals("US_crimson") || planetType.equals("US_storm") || planetType.equals("fds_desert") || planetType.equals("SCY_homePlanet") || planetType.equals("istl_aridbread") || planetType.equals("vayra_bread") || planetType.equals("US_auric") || planetType.equals("US_auricCloudy")) {
-            return "desert";
-        } else if (planetType.equals("terran") || planetType.equals("terran-eccentric") || planetType.equals("US_lifeless") || planetType.equals("US_alkali") || planetType.equals("US_continent") || planetType.equals("US_magnetic") || planetType.equals("US_water") || planetType.equals("US_waterB") || planetType.equals("terran_adapted")) {
-            return "terran";
-        } else if (planetType.equals("water")) {
-            return "water";
-        } else if (planetType.equals("tundra") || planetType.equals("US_purple") || planetType.equals("fds_tundra") || planetType.equals("galaxytigers_tundra")) {
-            return "tundra";
-        } else if (planetType.equals("jungle") || planetType.equals("US_jungle") || planetType.equals("jungle_charkha")) {
-            return "jungle";
-        } else if (planetType.equals("frozen") || planetType.equals("frozen1") || planetType.equals("frozen2") || planetType.equals("frozen3") || planetType.equals("cryovolcanic") || planetType.equals("US_iceA") || planetType.equals("US_iceB") || planetType.equals("US_blue") || planetType.equals("fds_cryovolcanic") || planetType.equals("fds_frozen")) {
-            return "frozen";
-        } else if (planetType.equals("lava") || planetType.equals("lava_minor") || planetType.equals("US_lava") || planetType.equals("US_volcanic") || planetType.equals("fds_lava")) {
-            return "volcanic";
-        } else {
-            return "unknown";
+        switch (planetType) {
+            case "nebula_center_old":
+            case "nebula_center_average":
+            case "nebula_center_young":
+            case "star_neutron":
+            case "black_hole":
+            case "star_yellow":
+            case "star_white":
+            case "star_blue_giant":
+            case "star_blue_supergiant":
+            case "star_orange":
+            case "star_orange_giant":
+            case "star_red_supergiant":
+            case "star_red_giant":
+            case "star_red_dwarf":
+            case "star_browndwarf":
+            case "US_star_blue_giant":
+            case "US_star_yellow":
+            case "US_star_orange":
+            case "US_star_red_giant":
+            case "US_star_white":
+            case "US_star_browndwarf":
+            case "SCY_star":
+            case "SCY_companionStar":
+            case "SCY_wormholeUnder":
+            case "SCY_wormholeA":
+            case "SCY_wormholeB":
+            case "SCY_wormholeC":
+            case "istl_sigmaworld":
+            case "istl_dysonshell":
+            case "vayra_star_blue":
+            case "vayra_star_brown":
+            case "vayra_star_yellow_white":
+                return "star";
+            case "gas_giant":
+            case "ice_giant":
+            case "US_gas_giant":
+            case "US_gas_giantB":
+            case "fds_gas_giant":
+            case "SCY_tartarus":
+            case "galaxytigers_gas_giant":
+                return "gas_giant";
+            case "barren":
+            case "barren_castiron":
+            case "barren2":
+            case "barren3":
+            case "barren_venuslike":
+            case "rocky_metallic":
+            case "rocky_unstable":
+            case "rocky_ice":
+            case "irradiated":
+            case "barren-bombarded":
+            case "US_acid":
+            case "US_acidRain":
+            case "US_acidWind":
+            case "US_barrenA":
+            case "US_barrenB":
+            case "US_barrenC":
+            case "US_barrenD":
+            case "US_barrenE":
+            case "US_barrenF":
+            case "US_azure":
+            case "US_burnt":
+            case "US_artificial":
+            case "haunted":
+            case "hmi_crystalline":
+            case "SCY_miningColony":
+            case "SCY_burntPlanet":
+            case "SCY_moon":
+            case "SCY_redRock":
+            case "rad_planet":
+            case "ecumenopolis":
+            case "nskr_ice_desert":
+                return "barren";
+            case "toxic":
+            case "toxic_cold":
+            case "US_green":
+            case "SCY_acid":
+                return "toxic";
+            case "desert":
+            case "desert1":
+            case "arid":
+            case "barren-desert":
+            case "US_dust":
+            case "US_desertA":
+            case "US_desertB":
+            case "US_desertC":
+            case "US_red":
+            case "US_redWind":
+            case "US_lifelessArid":
+            case "US_arid":
+            case "US_crimson":
+            case "US_storm":
+            case "fds_desert":
+            case "SCY_homePlanet":
+            case "istl_aridbread":
+            case "vayra_bread":
+            case "US_auric":
+            case "US_auricCloudy":
+                return "desert";
+            case "terran":
+            case "terran-eccentric":
+            case "US_lifeless":
+            case "US_alkali":
+            case "US_continent":
+            case "US_magnetic":
+            case "US_water":
+            case "US_waterB":
+            case "terran_adapted":
+                return "terran";
+            case "water":
+                return "water";
+            case "tundra":
+            case "US_purple":
+            case "fds_tundra":
+            case "galaxytigers_tundra":
+                return "tundra";
+            case "jungle":
+            case "US_jungle":
+            case "jungle_charkha":
+                return "jungle";
+            case "frozen":
+            case "frozen1":
+            case "frozen2":
+            case "frozen3":
+            case "cryovolcanic":
+            case "US_iceA":
+            case "US_iceB":
+            case "US_blue":
+            case "fds_cryovolcanic":
+            case "fds_frozen":
+                return "frozen";
+            case "lava":
+            case "lava_minor":
+            case "US_lava":
+            case "US_volcanic":
+            case "fds_lava":
+                return "volcanic";
+            default:
+                return "unknown";
         }
     }
 
@@ -831,11 +900,7 @@ public class boggledTools
     }
 
     public static boolean marketIsStation(MarketAPI market) {
-        if (market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.getPrimaryEntity().hasTag("station")) {
-            return true;
-        } else {
-            return false;
-        }
+        return market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.getPrimaryEntity().hasTag("station");
     }
 
     public static boolean terraformingPossibleOnMarket(MarketAPI market) {
@@ -848,11 +913,7 @@ public class boggledTools
         }
 
         String planetType = boggledTools.getPlanetType(market.getPlanetEntity());
-        if (planetType.equals("star") || planetType.equals("gas_giant") || planetType.equals("volcanic") || planetType.equals("unknown")) {
-            return false;
-        }
-
-        return true;
+        return !planetType.equals("star") && !planetType.equals("gas_giant") && !planetType.equals("volcanic") && !planetType.equals("unknown");
     }
 
     public static boolean getCreateMirrorsOrShades(MarketAPI market) {
@@ -876,17 +937,12 @@ public class boggledTools
 
     public static SectorEntityToken getFocusOfAsteroidBelt(SectorEntityToken playerFleet)
     {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if ((terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin)) && terrainPlugin.containsEntity(playerFleet))
-                {
+                if ((terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin)) && terrainPlugin.containsEntity(playerFleet)) {
                     return entity.getOrbitFocus();
                 }
             }
@@ -897,22 +953,15 @@ public class boggledTools
 
     public static OrbitAPI getAsteroidFieldOrbit(SectorEntityToken playerFleet)
     {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet))
-                {
+                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet)) {
                     AsteroidFieldTerrainPlugin asteroidPlugin = (AsteroidFieldTerrainPlugin) terrain.getPlugin();
                     return asteroidPlugin.getEntity().getOrbit();
-                }
-                else
-                {
+                } else {
                     return null;
                 }
             }
@@ -923,17 +972,12 @@ public class boggledTools
 
     public static SectorEntityToken getAsteroidFieldEntity(SectorEntityToken playerFleet)
     {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet))
-                {
+                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet)) {
                     return terrain;
                 }
             }
@@ -945,17 +989,12 @@ public class boggledTools
 
     public static boolean playerFleetInAsteroidBelt(SectorEntityToken playerFleet)
     {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if ((terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin)) && terrainPlugin.containsEntity(playerFleet))
-                {
+                if ((terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin)) && terrainPlugin.containsEntity(playerFleet)) {
                     return true;
                 }
             }
@@ -966,17 +1005,12 @@ public class boggledTools
 
     public static boolean playerFleetInAsteroidField(SectorEntityToken playerFleet)
     {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet))
-                {
+                if (terrainPlugin instanceof AsteroidFieldTerrainPlugin && terrainPlugin.containsEntity(playerFleet)) {
                     return true;
                 }
             }
@@ -986,9 +1020,7 @@ public class boggledTools
     }
 
     public static boolean playerFleetTooCloseToJumpPoint(SectorEntityToken playerFleet) {
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext()) {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
             if (entity instanceof JumpPointAPI && getDistanceBetweenTokens(playerFleet, entity) < 300f) {
                 return true;
             }
@@ -1000,17 +1032,12 @@ public class boggledTools
     public static Integer getNumAsteroidTerrainsInSystem(SectorEntityToken playerFleet)
     {
         Integer numRoids = 0;
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if (terrainPlugin instanceof AsteroidBeltTerrainPlugin)
-                {
+                if (terrainPlugin instanceof AsteroidBeltTerrainPlugin) {
                     numRoids++;
                 }
 
@@ -1032,17 +1059,12 @@ public class boggledTools
     public static Integer getNumAsteroidBeltsInSystem(SectorEntityToken playerFleet)
     {
         Integer numBelts = 0;
-        Iterator allEntitiesInSystem = playerFleet.getStarSystem().getAllEntities().iterator();
-        while (allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if (entity instanceof CampaignTerrainAPI)
-            {
+        for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
+            if (entity instanceof CampaignTerrainAPI) {
                 CampaignTerrainAPI terrain = (CampaignTerrainAPI) entity;
                 CampaignTerrainPlugin terrainPlugin = terrain.getPlugin();
 
-                if (terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin))
-                {
+                if (terrainPlugin instanceof AsteroidBeltTerrainPlugin && !(terrainPlugin instanceof AsteroidFieldTerrainPlugin)) {
                     numBelts++;
                 }
             }
@@ -1071,9 +1093,7 @@ public class boggledTools
     }
 
     public static int getNumberOfStationExpansions(MarketAPI market) {
-        Iterator allTagsOnMarket = market.getTags().iterator();
-        while (allTagsOnMarket.hasNext()) {
-            String tag = (String) allTagsOnMarket.next();
+        for (String tag : market.getTags()) {
             if (tag.contains("boggled_station_construction_numExpansions_")) {
                 return Integer.parseInt(tag.substring(tag.length() - 1));
             }
@@ -1094,14 +1114,7 @@ public class boggledTools
 
     public static boolean systemHasJumpPoint(StarSystemAPI system)
     {
-        if(system.getJumpPoints().isEmpty())
-        {
-            return false;
-        }
-        else
-        {
-            return true;
-        }
+        return !system.getJumpPoints().isEmpty();
     }
 
     public static float randomOrbitalAngleFloat()
@@ -1136,19 +1149,13 @@ public class boggledTools
 
     public static void clearConnectedPlanets(MarketAPI market)
     {
-        Iterator removePlanets = market.getConnectedEntities().iterator();
         SectorEntityToken targetEntityToRemove = null;
-
-        while(removePlanets.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)removePlanets.next();
-            if (entity instanceof PlanetAPI && !entity.hasTag("station"))
-            {
+        for (SectorEntityToken entity : market.getConnectedEntities()) {
+            if (entity instanceof PlanetAPI && !entity.hasTag("station")) {
                 targetEntityToRemove = entity;
             }
         }
 
-        removePlanets = null;
         if(targetEntityToRemove != null)
         {
             market.getConnectedEntities().remove(targetEntityToRemove);
@@ -1158,19 +1165,13 @@ public class boggledTools
 
     public static void clearConnectedStations(MarketAPI market)
     {
-        Iterator removeStations = market.getConnectedEntities().iterator();
         SectorEntityToken targetEntityToRemove = null;
-
-        while(removeStations.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)removeStations.next();
-            if (entity.hasTag("station"))
-            {
+        for (SectorEntityToken entity : market.getConnectedEntities()) {
+            if (entity.hasTag("station")) {
                 targetEntityToRemove = entity;
             }
         }
 
-        removeStations = null;
         if(targetEntityToRemove != null)
         {
             market.getConnectedEntities().remove(targetEntityToRemove);
@@ -1181,13 +1182,9 @@ public class boggledTools
     public static int numReflectorsInOrbit(MarketAPI market)
     {
         int numReflectors = 0;
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
 
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.getId().contains("stellar_shade") || entity.hasTag("stellar_mirror") || entity.hasTag("stellar_shade")))
-            {
+        for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.getId().contains("stellar_shade") || entity.hasTag("stellar_mirror") || entity.hasTag("stellar_shade"))) {
                 numReflectors++;
             }
         }
@@ -1198,13 +1195,9 @@ public class boggledTools
     public static int numMirrorsInOrbit(MarketAPI market)
     {
         int numMirrors = 0;
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
 
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.hasTag("stellar_mirror")))
-            {
+        for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.hasTag("stellar_mirror"))) {
                 numMirrors++;
             }
         }
@@ -1215,13 +1208,9 @@ public class boggledTools
     public static int numShadesInOrbit(MarketAPI market)
     {
         int numShades = 0;
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
 
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_shade") || entity.hasTag("stellar_shade")))
-            {
+        for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_shade") || entity.hasTag("stellar_shade"))) {
                 numShades++;
             }
         }
@@ -1231,8 +1220,7 @@ public class boggledTools
 
     public static void clearReflectorsInOrbit(MarketAPI market)
     {
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
-
+        Iterator<SectorEntityToken> allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
         while(allEntitiesInSystem.hasNext())
         {
             SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
@@ -1246,12 +1234,8 @@ public class boggledTools
 
     public static boolean hasIsmaraSling(MarketAPI market)
     {
-        Iterator marketsInSystem = Global.getSector().getEconomy().getMarkets(market.getStarSystem()).iterator();
-        while(marketsInSystem.hasNext())
-        {
-            MarketAPI marketElement = (MarketAPI)marketsInSystem.next();
-            if(marketElement.getFactionId().equals(market.getFactionId()) && marketElement.hasIndustry("BOGGLED_ISMARA_SLING") && marketElement.getIndustry("BOGGLED_ISMARA_SLING").isFunctional())
-            {
+        for (MarketAPI marketElement : Global.getSector().getEconomy().getMarkets(market.getStarSystem())) {
+            if (marketElement.getFactionId().equals(market.getFactionId()) && marketElement.hasIndustry("BOGGLED_ISMARA_SLING") && marketElement.getIndustry("BOGGLED_ISMARA_SLING").isFunctional()) {
                 return true;
             }
         }
@@ -1292,26 +1276,23 @@ public class boggledTools
             return;
         }
 
-        if(stationType.equals("astropolis"))
-        {
-            newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + stationGreekLetter + "_" + size, market.getFactionId());
-            newStationLights = system.addCustomEntity("boggled_station_lights_overlay_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName() + " Lights Overlay", "boggled_" + stationType + "_station_" + stationGreekLetter + "_" + size + "_lights_overlay", market.getFactionId());
-        }
-        else if(stationType.equals("mining"))
-        {
-            newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + size, market.getFactionId());
-            //We can't tell which lights overlay to delete earlier because there could be multiple mining stations in a single system.
-            //Therefore we delete them all earlier, then recreate them all later.
-        }
-        else if(stationType.equals("siphon"))
-        {
-            newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + size, market.getFactionId());
-            newStationLights = system.addCustomEntity("boggled_station_lights_overlay_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName() + " Lights Overlay", "boggled_" + stationType + "_station_" + size + "_lights_overlay", market.getFactionId());
-        }
-        else
-        {
-            //Do nothing because the station type is unrecognized
-            return;
+        switch (stationType) {
+            case "astropolis":
+                newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + stationGreekLetter + "_" + size, market.getFactionId());
+                newStationLights = system.addCustomEntity("boggled_station_lights_overlay_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName() + " Lights Overlay", "boggled_" + stationType + "_station_" + stationGreekLetter + "_" + size + "_lights_overlay", market.getFactionId());
+                break;
+            case "mining":
+                newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + size, market.getFactionId());
+                //We can't tell which lights overlay to delete earlier because there could be multiple mining stations in a single system.
+                //Therefore we delete them all earlier, then recreate them all later.
+                break;
+            case "siphon":
+                newStation = system.addCustomEntity("boggled_station_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName(), "boggled_" + stationType + "_station_" + size, market.getFactionId());
+                newStationLights = system.addCustomEntity("boggled_station_lights_overlay_swapped_" + clock.getCycle() + "_" + clock.getMonth() + "_" + clock.getDay(), station.getName() + " Lights Overlay", "boggled_" + stationType + "_station_" + size + "_lights_overlay", market.getFactionId());
+                break;
+            default:
+                //Do nothing because the station type is unrecognized
+                return;
         }
 
         if(newStation == null)
@@ -1338,30 +1319,22 @@ public class boggledTools
         newStation.setFaction(market.getFactionId());
         station.setCircularOrbit(newStation, 0, 0, 1);
 
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station))
-            {
-                if (entity.getOrbit().getClass().equals(CircularFleetOrbit.class))
-                {
-                    ((CircularFleetOrbit)entity.getOrbit()).setFocus(newStation);
+        for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station)) {
+                if (entity.getOrbit().getClass().equals(CircularFleetOrbit.class)) {
+                    ((CircularFleetOrbit) entity.getOrbit()).setFocus(newStation);
                 }
 
-                if (entity.getOrbit().getClass().equals(CircularOrbit.class))
-                {
-                    ((CircularOrbit)entity.getOrbit()).setFocus(newStation);
+                if (entity.getOrbit().getClass().equals(CircularOrbit.class)) {
+                    ((CircularOrbit) entity.getOrbit()).setFocus(newStation);
                 }
 
-                if (entity.getOrbit().getClass().equals(CircularOrbitPointDown.class))
-                {
-                    ((CircularOrbitPointDown)entity.getOrbit()).setFocus(newStation);
+                if (entity.getOrbit().getClass().equals(CircularOrbitPointDown.class)) {
+                    ((CircularOrbitPointDown) entity.getOrbit()).setFocus(newStation);
                 }
 
-                if (entity.getOrbit().getClass().equals(CircularOrbitWithSpin.class))
-                {
-                    ((CircularOrbitWithSpin)entity.getOrbit()).setFocus(newStation);
+                if (entity.getOrbit().getClass().equals(CircularOrbitWithSpin.class)) {
+                    ((CircularOrbitWithSpin) entity.getOrbit()).setFocus(newStation);
                 }
             }
         }
@@ -1427,119 +1400,91 @@ public class boggledTools
             orbit = station.getOrbit();
         }
 
-        if(stationType.equals("astropolis"))
-        {
-            SectorEntityToken targetTokenToDelete = null;
+        switch (stationType) {
+            case "astropolis": {
+                SectorEntityToken targetTokenToDelete = null;
 
-            if(stationGreekLetter.equals("alpha"))
-            {
-                Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-                while(allEntitiesInSystem.hasNext())
-                {
-                    SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                    if(entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_alpha_small") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_medium") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_large")))
-                    {
+                switch (stationGreekLetter) {
+                    case "alpha": {
+                        for (SectorEntityToken entity : system.getAllEntities()) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_alpha_small") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_medium") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_large"))) {
+                                targetTokenToDelete = entity;
+                                break;
+                            }
+                        }
+
+                        if (targetTokenToDelete != null) {
+                            system.removeEntity(targetTokenToDelete);
+                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
+                        }
+                        break;
+                    }
+                    case "beta": {
+                        for (SectorEntityToken entity : system.getAllEntities()) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_beta_small") || entity.hasTag("boggled_lights_overlay_astropolis_beta_medium") || entity.hasTag("boggled_lights_overlay_astropolis_beta_large"))) {
+                                targetTokenToDelete = entity;
+                                break;
+                            }
+                        }
+
+                        if (targetTokenToDelete != null) {
+                            system.removeEntity(targetTokenToDelete);
+                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
+                        }
+                        break;
+                    }
+                    case "gamma": {
+                        for (SectorEntityToken entity : system.getAllEntities()) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_gamma_small") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_medium") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_large"))) {
+                                targetTokenToDelete = entity;
+                                break;
+                            }
+                        }
+
+                        if (targetTokenToDelete != null) {
+                            system.removeEntity(targetTokenToDelete);
+                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
+                        }
+                        break;
+                    }
+                }
+                break;
+            }
+            case "mining": {
+                SectorEntityToken targetTokenToDelete = null;
+
+                for (SectorEntityToken entity : system.getAllEntities()) {
+                    if (entity.hasTag("boggled_lights_overlay_mining_small") || entity.hasTag("boggled_lights_overlay_mining_medium")) {
                         targetTokenToDelete = entity;
                         break;
                     }
                 }
-                allEntitiesInSystem = null;
 
-                if(targetTokenToDelete != null)
-                {
+                if (targetTokenToDelete != null) {
                     system.removeEntity(targetTokenToDelete);
                     deleteOldLightsOverlay(station, stationType, stationGreekLetter);
                 }
+                break;
             }
-            else if(stationGreekLetter.equals("beta"))
-            {
-                Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-                while(allEntitiesInSystem.hasNext())
-                {
-                    SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                    if(entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_beta_small") || entity.hasTag("boggled_lights_overlay_astropolis_beta_medium") || entity.hasTag("boggled_lights_overlay_astropolis_beta_large")))
-                    {
+            case "siphon": {
+                SectorEntityToken targetTokenToDelete = null;
+
+                for (SectorEntityToken entity : system.getAllEntities()) {
+                    if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && (entity.hasTag("boggled_lights_overlay_siphon_small") || entity.hasTag("boggled_lights_overlay_siphon_medium"))) {
                         targetTokenToDelete = entity;
                         break;
                     }
                 }
-                allEntitiesInSystem = null;
 
-                if(targetTokenToDelete != null)
-                {
+                if (targetTokenToDelete != null) {
                     system.removeEntity(targetTokenToDelete);
                     deleteOldLightsOverlay(station, stationType, stationGreekLetter);
                 }
+                break;
             }
-            else if(stationGreekLetter.equals("gamma"))
-            {
-                Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-                while(allEntitiesInSystem.hasNext())
-                {
-                    SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                    if(entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_gamma_small") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_medium") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_large")))
-                    {
-                        targetTokenToDelete = entity;
-                        break;
-                    }
-                }
-                allEntitiesInSystem = null;
-
-                if(targetTokenToDelete != null)
-                {
-                    system.removeEntity(targetTokenToDelete);
-                    deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                }
-            }
-        }
-        else if(stationType.equals("mining"))
-        {
-            SectorEntityToken targetTokenToDelete = null;
-
-            Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-            while(allEntitiesInSystem.hasNext())
-            {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                if(entity.hasTag("boggled_lights_overlay_mining_small") || entity.hasTag("boggled_lights_overlay_mining_medium"))
-                {
-                    targetTokenToDelete = entity;
-                    break;
-                }
-            }
-            allEntitiesInSystem = null;
-
-            if(targetTokenToDelete != null)
-            {
-                system.removeEntity(targetTokenToDelete);
-                deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-            }
-        }
-        else if(stationType.equals("siphon"))
-        {
-            SectorEntityToken targetTokenToDelete = null;
-
-            Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-            while(allEntitiesInSystem.hasNext())
-            {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                if(entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && (entity.hasTag("boggled_lights_overlay_siphon_small") || entity.hasTag("boggled_lights_overlay_siphon_medium")))
-                {
-                    targetTokenToDelete = entity;
-                    break;
-                }
-            }
-            allEntitiesInSystem = null;
-
-            if(targetTokenToDelete != null)
-            {
-                system.removeEntity(targetTokenToDelete);
-                deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-            }
-        }
-        else
-        {
-            //Do nothing because the station type is unrecognized
-            return;
+            default:
+                //Do nothing because the station type is unrecognized
+                return;
         }
     }
 
@@ -1548,26 +1493,19 @@ public class boggledTools
         SectorEntityToken stationToApplyOverlayTo = null;
         int stationsize = 0;
 
-        Iterator allEntitiesInSystem = system.getAllEntities().iterator();
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if(entity.hasTag("boggled_mining_station_small") && !entity.hasTag("boggled_already_reapplied_lights_overlay"))
-            {
+        for (SectorEntityToken entity : system.getAllEntities()) {
+            if (entity.hasTag("boggled_mining_station_small") && !entity.hasTag("boggled_already_reapplied_lights_overlay")) {
                 stationToApplyOverlayTo = entity;
                 stationsize = 1;
                 entity.addTag("boggled_already_reapplied_lights_overlay");
                 break;
-            }
-            else if(entity.hasTag("boggled_mining_station_medium") && !entity.hasTag("boggled_already_reapplied_lights_overlay"))
-            {
+            } else if (entity.hasTag("boggled_mining_station_medium") && !entity.hasTag("boggled_already_reapplied_lights_overlay")) {
                 stationToApplyOverlayTo = entity;
                 stationsize = 2;
                 entity.addTag("boggled_already_reapplied_lights_overlay");
                 break;
             }
         }
-        allEntitiesInSystem = null;
 
         if(stationToApplyOverlayTo != null)
         {
@@ -1592,12 +1530,8 @@ public class boggledTools
         }
         else
         {
-            allEntitiesInSystem = system.getAllEntities().iterator();
-            while(allEntitiesInSystem.hasNext())
-            {
-                SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-                if(entity.hasTag("boggled_already_reapplied_lights_overlay"))
-                {
+            for (SectorEntityToken entity : system.getAllEntities()) {
+                if (entity.hasTag("boggled_already_reapplied_lights_overlay")) {
                     entity.removeTag("boggled_already_reapplied_lights_overlay");
                 }
             }
@@ -1606,12 +1540,8 @@ public class boggledTools
 
     public static boolean marketHasOrbitalStation(MarketAPI market)
     {
-        Iterator allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
-        while(allEntitiesInSystem.hasNext())
-        {
-            SectorEntityToken entity = (SectorEntityToken) allEntitiesInSystem.next();
-            if(entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && entity.hasTag("station"))
-            {
+        for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && entity.hasTag("station")) {
                 return true;
             }
         }
@@ -1989,27 +1919,17 @@ public class boggledTools
         SectorEntityToken closestGasGiantToken = market.getPrimaryEntity();
         if(closestGasGiantToken != null)
         {
-            Iterator allEntitiesInSystem = closestGasGiantToken.getStarSystem().getAllEntities().iterator();
-            while(allEntitiesInSystem.hasNext())
-            {
-                SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-                if(entity.hasTag("station") && entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(closestGasGiantToken) && (entity.getCustomEntitySpec().getDefaultName().equals("Side Station") || entity.getCustomEntitySpec().getDefaultName().equals("Siphon Station")) && !entity.getId().equals("beholder_station"))
-                {
-                    if(entity.getMarket() != null)
-                    {
+            for (SectorEntityToken entity : closestGasGiantToken.getStarSystem().getAllEntities()) {
+                if (entity.hasTag("station") && entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(closestGasGiantToken) && (entity.getCustomEntitySpec().getDefaultName().equals("Side Station") || entity.getCustomEntitySpec().getDefaultName().equals("Siphon Station")) && !entity.getId().equals("beholder_station")) {
+                    if (entity.getMarket() != null) {
                         market = entity.getMarket();
-                        if(market.hasCondition("volatiles_trace"))
-                        {
+                        if (market.hasCondition("volatiles_trace")) {
                             boggledTools.removeCondition(market, "volatiles_trace");
                             boggledTools.addCondition(market, "volatiles_abundant");
-                        }
-                        else if(market.hasCondition("volatiles_diffuse"))
-                        {
+                        } else if (market.hasCondition("volatiles_diffuse")) {
                             boggledTools.removeCondition(market, "volatiles_diffuse");
                             boggledTools.addCondition(market, "volatiles_plentiful");
-                        }
-                        else if(market.hasCondition("volatiles_abundant"))
-                        {
+                        } else if (market.hasCondition("volatiles_abundant")) {
                             boggledTools.removeCondition(market, "volatiles_abundant");
                             boggledTools.addCondition(market, "volatiles_plentiful");
                         }
@@ -2241,182 +2161,174 @@ public class boggledTools
     {
         // Not currently in use due to lack of Unknown Skies terraforming options
         // Highly likely to implement in the future
-        if(newPlanetType.equals("auric"))
-        {
-            newPlanetType = "US_auric";
-        }
-        else if(newPlanetType.equals("archipelago"))
-        {
-            newPlanetType = "US_water";
-        }
-        else if(newPlanetType.equals("continental"))
-        {
-            newPlanetType = "US_continent";
+        switch (newPlanetType) {
+            case "auric":
+                newPlanetType = "US_auric";
+                break;
+            case "archipelago":
+                newPlanetType = "US_water";
+                break;
+            case "continental":
+                newPlanetType = "US_continent";
+                break;
         }
 
         market.getPlanetEntity().changeType(newPlanetType, null);
 
-        if(newPlanetType.equals("jungle"))
-        {
-            // Modded conditions
-            removeCondition(market, "US_storm");
+        switch (newPlanetType) {
+            case "jungle":
+                // Modded conditions
+                removeCondition(market, "US_storm");
 
-            // Vanilla Conditions
-            addCondition(market, "habitable");
-            removeCondition(market, "water_surface");
-            removeCondition(market, "volturnian_lobster_pens");
+                // Vanilla Conditions
+                addCondition(market, "habitable");
+                removeCondition(market, "water_surface");
+                removeCondition(market, "volturnian_lobster_pens");
 
-            removeCondition(market, "farmland_poor");
-            addCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
+                removeCondition(market, "farmland_poor");
+                addCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
 
-            removeCondition(market, "organics_trace");
-            addCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
+                removeCondition(market, "organics_trace");
+                addCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
 
-            removeCondition(market, "volatiles_trace");
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
-        }
-        else if(newPlanetType.equals("arid"))
-        {
-            // Modded conditions
-
-            // Vanilla Conditions
-            addCondition(market, "habitable");
-            removeCondition(market, "water_surface");
-            removeCondition(market, "volturnian_lobster_pens");
-
-            removeCondition(market, "farmland_poor");
-            addCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
-
-            removeCondition(market, "organics_trace");
-            addCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
-
-            removeCondition(market, "volatiles_trace");
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
-        }
-        else if(newPlanetType.equals("terran") || newPlanetType.equals("US_auric") || newPlanetType.equals("US_water") || newPlanetType.equals("US_continent"))
-        {
-            // Modded conditions
-            removeCondition(market, "US_storm");
-
-            // Vanilla Conditions
-            addCondition(market, "habitable");
-            removeCondition(market, "water_surface");
-            removeCondition(market, "volturnian_lobster_pens");
-
-            removeCondition(market, "farmland_poor");
-            addCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
-
-            addCondition(market, "organics_trace");
-            removeCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
-
-            if(boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles"))
-            {
-                addCondition(market, "volatiles_trace");
-            }
-            else
-            {
                 removeCondition(market, "volatiles_trace");
-            }
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
-        }
-        else if(newPlanetType.equals("water"))
-        {
-            // Modded conditions
-            removeCondition(market, "US_storm");
+                removeCondition(market, "volatiles_diffuse");
+                removeCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
+            case "arid":
+                // Modded conditions
 
-            // Vanilla Conditions
-            addCondition(market, "habitable");
-            addCondition(market, "water_surface");
+                // Vanilla Conditions
+                addCondition(market, "habitable");
+                removeCondition(market, "water_surface");
+                removeCondition(market, "volturnian_lobster_pens");
 
-            removeCondition(market, "farmland_poor");
-            removeCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
+                removeCondition(market, "farmland_poor");
+                addCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
 
-            removeCondition(market, "organics_trace");
-            removeCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
+                removeCondition(market, "organics_trace");
+                addCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
 
-            removeCondition(market, "volatiles_trace");
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
-        }
-        else if(newPlanetType.equals("tundra"))
-        {
-            // Modded conditions
-            removeCondition(market, "US_storm");
-
-            // Vanilla Conditions
-            addCondition(market, "habitable");
-            removeCondition(market, "water_surface");
-            removeCondition(market, "volturnian_lobster_pens");
-
-            removeCondition(market, "farmland_poor");
-            addCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
-
-            addCondition(market, "organics_trace");
-            removeCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
-
-            if(boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles"))
-            {
-                addCondition(market, "volatiles_trace");
-            }
-            else
-            {
                 removeCondition(market, "volatiles_trace");
-            }
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
-        }
-        else if(newPlanetType.equals("frozen"))
-        {
-            // Modded conditions
-            removeCondition(market, "US_storm");
+                removeCondition(market, "volatiles_diffuse");
+                removeCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
+            case "terran":
+            case "US_auric":
+            case "US_water":
+            case "US_continent":
+                // Modded conditions
+                removeCondition(market, "US_storm");
 
-            // Vanilla Conditions
-            removeCondition(market, "habitable");
-            removeCondition(market, "water_surface");
-            removeCondition(market, "volturnian_lobster_pens");
+                // Vanilla Conditions
+                addCondition(market, "habitable");
+                removeCondition(market, "water_surface");
+                removeCondition(market, "volturnian_lobster_pens");
 
-            removeCondition(market, "farmland_poor");
-            removeCondition(market, "farmland_adequate");
-            removeCondition(market, "farmland_rich");
-            removeCondition(market, "farmland_bountiful");
+                removeCondition(market, "farmland_poor");
+                addCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
 
-            removeCondition(market, "organics_trace");
-            removeCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
+                addCondition(market, "organics_trace");
+                removeCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
 
-            removeCondition(market, "volatiles_trace");
-            removeCondition(market, "volatiles_diffuse");
-            addCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
+                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
+                    addCondition(market, "volatiles_trace");
+                } else {
+                    removeCondition(market, "volatiles_trace");
+                }
+                removeCondition(market, "volatiles_diffuse");
+                removeCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
+            case "water":
+                // Modded conditions
+                removeCondition(market, "US_storm");
+
+                // Vanilla Conditions
+                addCondition(market, "habitable");
+                addCondition(market, "water_surface");
+
+                removeCondition(market, "farmland_poor");
+                removeCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
+
+                removeCondition(market, "organics_trace");
+                removeCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
+
+                removeCondition(market, "volatiles_trace");
+                removeCondition(market, "volatiles_diffuse");
+                removeCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
+            case "tundra":
+                // Modded conditions
+                removeCondition(market, "US_storm");
+
+                // Vanilla Conditions
+                addCondition(market, "habitable");
+                removeCondition(market, "water_surface");
+                removeCondition(market, "volturnian_lobster_pens");
+
+                removeCondition(market, "farmland_poor");
+                addCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
+
+                addCondition(market, "organics_trace");
+                removeCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
+
+                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
+                    addCondition(market, "volatiles_trace");
+                } else {
+                    removeCondition(market, "volatiles_trace");
+                }
+                removeCondition(market, "volatiles_diffuse");
+                removeCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
+            case "frozen":
+                // Modded conditions
+                removeCondition(market, "US_storm");
+
+                // Vanilla Conditions
+                removeCondition(market, "habitable");
+                removeCondition(market, "water_surface");
+                removeCondition(market, "volturnian_lobster_pens");
+
+                removeCondition(market, "farmland_poor");
+                removeCondition(market, "farmland_adequate");
+                removeCondition(market, "farmland_rich");
+                removeCondition(market, "farmland_bountiful");
+
+                removeCondition(market, "organics_trace");
+                removeCondition(market, "organics_common");
+                removeCondition(market, "organics_abundant");
+                removeCondition(market, "organics_plentiful");
+
+                removeCondition(market, "volatiles_trace");
+                removeCondition(market, "volatiles_diffuse");
+                addCondition(market, "volatiles_abundant");
+                removeCondition(market, "volatiles_plentiful");
+                break;
         }
 
         surveyAll(market);
@@ -2491,10 +2403,7 @@ public class boggledTools
         else
         {
             String[] returnArray = new String[existingArray.length + 1];
-            for(int i = 0; i < existingArray.length; i++)
-            {
-                returnArray[i] = existingArray[i];
-            }
+            System.arraycopy(existingArray, 0, returnArray, 0, existingArray.length);
             returnArray[existingArray.length] = lineToAppend;
             return returnArray;
         }
@@ -2696,22 +2605,13 @@ public class boggledTools
         {
             if(market.hasIndustry(Industries.ORBITALWORKS) && market.getIndustry(Industries.ORBITALWORKS).isFunctional())
             {
-                Iterator visibleSpecialItems = market.getIndustry(Industries.ORBITALWORKS).getVisibleInstalledItems().iterator();
-                while(visibleSpecialItems.hasNext())
-                {
-                    SpecialItemData data = (SpecialItemData) visibleSpecialItems.next();
-                    if (data.getId().equals("pristine_nanoforge") || data.getId().equals("uaf_dimen_nanoforge"))
-                    {
+                for (SpecialItemData data : market.getIndustry(Industries.ORBITALWORKS).getVisibleInstalledItems()) {
+                    if (data.getId().equals("pristine_nanoforge") || data.getId().equals("uaf_dimen_nanoforge")) {
                         return true;
                     }
                 }
-
-                return false;
             }
-            else
-            {
-                return false;
-            }
+            return false;
         }
         else if(requirement.contains("Fleet cargo contains at least"))
         {
@@ -2722,14 +2622,7 @@ public class boggledTools
         else if(requirement.equals(boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost") + " story points available to spend"))
         {
             MutableCharacterStatsAPI charStats = Global.getSector().getPlayerStats();
-            if(charStats.getStoryPoints() >= boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost"))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
+            return charStats.getStoryPoints() >= boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost");
         }
 //        else if(requirement.equals(aotd_TypeChangeResearchRequirement))
 //        {
@@ -2752,11 +2645,8 @@ public class boggledTools
     public static boolean projectRequirementsMet(MarketAPI market, String project)
     {
         String[] requirements = getProjectRequirementsStrings(project);
-        int i = 0;
-        for (i = 0; i < requirements.length; i++)
-        {
-            if(!requirementMet(market, requirements[i]))
-            {
+        for (String requirement : requirements) {
+            if (!requirementMet(market, requirement)) {
                 return false;
             }
         }
@@ -2777,16 +2667,11 @@ public class boggledTools
             text.addPara("Project Requirements:", highlight, new String[]{""});
             String[] requirements = boggledTools.getProjectRequirementsStrings(project);
             Boolean foundUnmetRequirement = false;
-            int i;
-            for (i = 0; i < requirements.length; i++)
-            {
-                if(boggledTools.requirementMet(market, requirements[i]))
-                {
-                    text.addPara("      - %s", good, new String[]{requirements[i] + ""});
-                }
-                else
-                {
-                    text.addPara("      - %s", bad, new String[]{requirements[i] + ""});
+            for (String requirement : requirements) {
+                if (boggledTools.requirementMet(market, requirement)) {
+                    text.addPara("      - %s", good, new String[]{requirement + ""});
+                } else {
+                    text.addPara("      - %s", bad, new String[]{requirement + ""});
                     foundUnmetRequirement = true;
                 }
             }
@@ -2804,139 +2689,119 @@ public class boggledTools
         Color bad = Misc.getNegativeHighlightColor();
 
 
-        if(project.equals(aridTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+        switch (project) {
+            case aridTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Arid world starting resources:", highlight, new String[]{""});
-            text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
-            text.addPara("      - Arid world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - Bountiful farmland, abundant organics, trace volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(frozenTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Arid world starting resources:", highlight, new String[]{""});
+                text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
+                text.addPara("      - Arid world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - Bountiful farmland, abundant organics, trace volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case frozenTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Frozen world starting resources:", highlight, new String[]{""});
-            text.addPara("          - No farmland, no organics, abundant volatiles", highlight, new String[]{""});
-            text.addPara("      - Frozen world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - No farmland, no organics, plentiful volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(jungleTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Frozen world starting resources:", highlight, new String[]{""});
+                text.addPara("          - No farmland, no organics, abundant volatiles", highlight, new String[]{""});
+                text.addPara("      - Frozen world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - No farmland, no organics, plentiful volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case jungleTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Jungle world starting resources:", highlight, new String[]{""});
-            text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
-            text.addPara("      - Jungle world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - Bountiful farmland, plentiful organics, no volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(terranTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Jungle world starting resources:", highlight, new String[]{""});
+                text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
+                text.addPara("      - Jungle world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - Bountiful farmland, plentiful organics, no volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case terranTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Terran world starting resources:", highlight, new String[]{""});
-            if(boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles"))
-            {
-                text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
-            }
-            else
-            {
-                text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
-            }
-            text.addPara("      - Terran world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - Bountiful farmland, plentiful organics, trace volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(waterTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Terran world starting resources:", highlight, new String[]{""});
+                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
+                    text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
+                } else {
+                    text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
+                }
+                text.addPara("      - Terran world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - Bountiful farmland, plentiful organics, trace volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case waterTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Water world starting resources:", highlight, new String[]{""});
-            text.addPara("          - No organics, no volatiles", highlight, new String[]{""});
-            text.addPara("      - Water world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - Plentiful organics, plentiful volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(tundraTypeChangeProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Water world starting resources:", highlight, new String[]{""});
+                text.addPara("          - No organics, no volatiles", highlight, new String[]{""});
+                text.addPara("      - Water world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - Plentiful organics, plentiful volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case tundraTypeChangeProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Tundra world starting resources:", highlight, new String[]{""});
-            if(boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles"))
-            {
-                text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
-            }
-            else
-            {
-                text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
-            }
-            text.addPara("      - Tundra world maximum resources:", highlight, new String[]{""});
-            text.addPara("          - Bountiful farmland, trace organics, plentiful volatiles", highlight, new String[]{""});
-            text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
-        }
-        else if(project.equals(farmlandResourceImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Tundra world starting resources:", highlight, new String[]{""});
+                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
+                    text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
+                } else {
+                    text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
+                }
+                text.addPara("      - Tundra world maximum resources:", highlight, new String[]{""});
+                text.addPara("          - Bountiful farmland, trace organics, plentiful volatiles", highlight, new String[]{""});
+                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                break;
+            case farmlandResourceImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Farming yield improved by one", highlight, new String[]{""});
-        }
-        else if(project.equals(organicsResourceImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Farming yield improved by one", highlight, new String[]{""});
+                break;
+            case organicsResourceImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Organics yield improved by one", highlight, new String[]{""});
-        }
-        else if(project.equals(volatilesResourceImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Organics yield improved by one", highlight, new String[]{""});
+                break;
+            case volatilesResourceImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Volatiles yield improved by one", highlight, new String[]{""});
-        }
-        else if(project.equals(extremeWeatherConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Volatiles yield improved by one", highlight, new String[]{""});
+                break;
+            case extremeWeatherConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Extreme weather patterns remediated", highlight, new String[]{""});
-        }
-        else if(project.equals(mildClimateConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Extreme weather patterns remediated", highlight, new String[]{""});
+                break;
+            case mildClimateConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Climate made mild", highlight, new String[]{""});
-        }
-        else if(project.equals(habitableConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Climate made mild", highlight, new String[]{""});
+                break;
+            case habitableConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Atmosphere made human-breathable", highlight, new String[]{""});
-        }
-        else if(project.equals(atmosphereDensityConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Atmosphere made human-breathable", highlight, new String[]{""});
+                break;
+            case atmosphereDensityConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Atmosphere with Earth-like density created", highlight, new String[]{""});
-        }
-        else if(project.equals(toxicAtmosphereConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Atmosphere with Earth-like density created", highlight, new String[]{""});
+                break;
+            case toxicAtmosphereConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Atmospheric toxicity remediated", highlight, new String[]{""});
-        }
-        else if(project.equals(irradiatedConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Atmospheric toxicity remediated", highlight, new String[]{""});
+                break;
+            case irradiatedConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Radiation remediated", highlight, new String[]{""});
-        }
-        else if(project.equals(removeAtmosphereConditionImprovementProjectID))
-        {
-            text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("      - Radiation remediated", highlight, new String[]{""});
+                break;
+            case removeAtmosphereConditionImprovementProjectID:
+                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
 
-            text.addPara("      - Atmosphere removed", highlight, new String[]{""});
+                text.addPara("      - Atmosphere removed", highlight, new String[]{""});
+                break;
         }
     }
 
@@ -3321,12 +3186,8 @@ public class boggledTools
 
     public static int getLastDayCheckedForConstruction(SectorEntityToken stationEntity)
     {
-        Iterator allTagsOnStation = stationEntity.getTags().iterator();
-        while(allTagsOnStation.hasNext())
-        {
-            String tag = (String)allTagsOnStation.next();
-            if(tag.contains("boggled_construction_progress_lastDayChecked_"))
-            {
+        for (String tag : stationEntity.getTags()) {
+            if (tag.contains("boggled_construction_progress_lastDayChecked_")) {
                 return Integer.parseInt(tag.replaceAll("boggled_construction_progress_lastDayChecked_", ""));
             }
         }
@@ -3337,17 +3198,12 @@ public class boggledTools
     public static void clearClockCheckTagsForConstruction(SectorEntityToken stationEntity)
     {
         String tagToDelete = null;
-        Iterator allTagsOnStation = stationEntity.getTags().iterator();
-        while(allTagsOnStation.hasNext())
-        {
-            String tag = (String)allTagsOnStation.next();
-            if(tag.contains("boggled_construction_progress_lastDayChecked_"))
-            {
+        for (String tag : stationEntity.getTags()) {
+            if (tag.contains("boggled_construction_progress_lastDayChecked_")) {
                 tagToDelete = tag;
                 break;
             }
         }
-        allTagsOnStation = null;
 
         if(tagToDelete != null)
         {
@@ -3359,17 +3215,12 @@ public class boggledTools
     public static void clearBoggledTerraformingControllerTags(MarketAPI market)
     {
         String tagToDelete = null;
-        Iterator allTags = market.getTags().iterator();
-        while(allTags.hasNext())
-        {
-            String tag = (String)allTags.next();
-            if(tag.contains("boggledTerraformingController"))
-            {
+        for (String tag : market.getTags()) {
+            if (tag.contains("boggledTerraformingController")) {
                 tagToDelete = tag;
                 break;
             }
         }
-        allTags = null;
 
         if(tagToDelete != null)
         {
@@ -3380,12 +3231,8 @@ public class boggledTools
 
     public static int getConstructionProgressDays(SectorEntityToken stationEntity)
     {
-        Iterator allTagsOnStation = stationEntity.getTags().iterator();
-        while(allTagsOnStation.hasNext())
-        {
-            String tag = (String)allTagsOnStation.next();
-            if(tag.contains("boggled_construction_progress_days_"))
-            {
+        for (String tag : stationEntity.getTags()) {
+            if (tag.contains("boggled_construction_progress_days_")) {
                 return Integer.parseInt(tag.replaceAll("boggled_construction_progress_days_", ""));
             }
         }
@@ -3396,17 +3243,12 @@ public class boggledTools
     public static void clearProgressCheckTagsForConstruction(SectorEntityToken stationEntity)
     {
         String tagToDelete = null;
-        Iterator allTagsOnStation = stationEntity.getTags().iterator();
-        while(allTagsOnStation.hasNext())
-        {
-            String tag = (String)allTagsOnStation.next();
-            if(tag.contains("boggled_construction_progress_days_"))
-            {
+        for (String tag : stationEntity.getTags()) {
+            if (tag.contains("boggled_construction_progress_days_")) {
                 tagToDelete = tag;
                 break;
             }
         }
-        allTagsOnStation = null;
 
         if(tagToDelete != null)
         {

--- a/src/data/campaign/econ/boggledTools.java
+++ b/src/data/campaign/econ/boggledTools.java
@@ -11,10 +11,7 @@ import com.fs.starfarer.api.campaign.listeners.ListenerUtil;
 import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.characters.MutableCharacterStatsAPI;
 import com.fs.starfarer.api.impl.campaign.MilitaryResponseScript;
-import com.fs.starfarer.api.impl.campaign.ids.Conditions;
-import com.fs.starfarer.api.impl.campaign.ids.Factions;
-import com.fs.starfarer.api.impl.campaign.ids.Industries;
-import com.fs.starfarer.api.impl.campaign.ids.MemFlags;
+import com.fs.starfarer.api.impl.campaign.ids.*;
 import com.fs.starfarer.api.impl.campaign.intel.BaseIntelPlugin;
 import com.fs.starfarer.api.impl.campaign.intel.MessageIntel;
 import com.fs.starfarer.api.impl.campaign.intel.deciv.DecivTracker;
@@ -23,6 +20,7 @@ import com.fs.starfarer.api.impl.campaign.submarkets.StoragePlugin;
 import com.fs.starfarer.api.impl.campaign.terrain.AsteroidBeltTerrainPlugin;
 import com.fs.starfarer.api.impl.campaign.terrain.AsteroidFieldTerrainPlugin;
 import com.fs.starfarer.api.util.Misc;
+import com.fs.starfarer.api.util.Pair;
 import com.fs.starfarer.campaign.CircularFleetOrbit;
 import com.fs.starfarer.campaign.CircularOrbit;
 import com.fs.starfarer.campaign.CircularOrbitPointDown;
@@ -44,6 +42,116 @@ import static java.util.Arrays.asList;
 
 public class boggledTools
 {
+    public static class BoggledMods {
+        public static final String lunalibModID = "lunalib";
+        public static final String illustratedEntitiesModID = "illustrated_entities";
+        public static final String tascModID = "Terraforming & Station Construction";
+    }
+
+    private static class BoggledSettings {
+        public static final String miningStationUltrarichOre = "boggledMiningStationUltrarichOre";
+        public static final String miningStationRichOre = "boggledMiningStationRichOre";
+        public static final String miningStationAbundantOre = "boggledMiningStationAbundantOre";
+        public static final String miningStationModerateOre = "boggledMiningStationModerateOre";
+        public static final String miningStationSparseOre = "boggledMiningStationSparseOre";
+
+        public static final String domainTechCraftingArtifactCost = "boggledDomainTechCraftingArtifactCost";
+        public static final String domainTechCraftingStoryPointCost = "boggledDomainTechCraftingStoryPointCost";
+
+        public static final String miningStationLinkToResourceBelts = "boggledMiningStationLinkToResourceBelts";
+        public static final String miningStationStaticAmount = "boggledMiningStationStaticAmount";
+
+        public static final String siphonStationLinkToGasGiant = "boggledSiphonStationLinkToGasGiant";
+        public static final String siphonStationStaticAmount = "boggledSiphonStationStaticAmount";
+
+        public static final String domainArchaeologyEnabled = "boggledDomainArchaeologyEnabled";
+
+        public static final String terraformingTypeChangeAddVolatiles = "boggledTerraformingTypeChangeAddVolatiles";
+
+        public static final String stableLocationGateCostHeavyMachinery = "boggledStableLocationGateCostHeavyMachinery";
+        public static final String stableLocationGateCostMetals = "boggledStableLocationGateCostMetals";
+        public static final String stableLocationGateCostTransplutonics = "boggledStableLocationGateCostTransplutonics";
+        public static final String stableLocationGateCostDomainEraArtifacts = "boggledStableLocationGateCostDomainEraArtifacts";
+
+        public static final String stableLocationDomainTechStructureCostHeavyMachinery = "boggledStableLocationDomainTechStructureCostHeavyMachinery";
+        public static final String stableLocationDomainTechStructureCostMetals = "boggledStableLocationDomainTechStructureCostMetals";
+        public static final String stableLocationDomainTechStructureCostTransplutonics = "boggledStableLocationDomainTechStructureCostTransplutonics";
+        public static final String stableLocationDomainTechStructureCostDomainEraArtifacts = "boggledStableLocationDomainTechStructureCostDomainEraArtifacts";
+
+        public static final String marketSizeRequiredToBuildInactiveGate = "boggledMarketSizeRequiredToBuildInactiveGate";
+
+        public static final String planetKillerAllowDestructionOfColoniesMarkedAsEssentialForQuests = "boggledPlanetKillerAllowDestructionOfColoniesMarkedAsEssentialForQuests";
+    }
+
+    public static class BoggledTags {
+        public static final String constructionProgressDays = "boggled_construction_progress_days_";
+        public static final String constructionProgressLastDayChecked = "boggled_construction_progress_lastDayChecked_";
+
+        public static final String terraformingController = "boggledTerraformingController";
+
+        public static final String lightsOverlayAstropolisAlphaSmall = "boggled_lights_overlay_astropolis_alpha_small";
+        public static final String lightsOverlayAstropolisAlphaMedium = "boggled_lights_overlay_astropolis_alpha_medium";
+        public static final String lightsOverlayAstropolisAlphaLarge = "boggled_lights_overlay_astropolis_alpha_large";
+
+        public static final String lightsOverlayAstropolisBetaSmall = "boggled_lights_overlay_astropolis_beta_small";
+        public static final String lightsOverlayAstropolisBetaMedium = "boggled_lights_overlay_astropolis_beta_medium";
+        public static final String lightsOverlayAstropolisBetaLarge = "boggled_lights_overlay_astropolis_beta_large";
+
+        public static final String lightsOverlayAstropolisGammaSmall = "boggled_lights_overlay_astropolis_gamma_small";
+        public static final String lightsOverlayAstropolisGammaMedium = "boggled_lights_overlay_astropolis_gamma_medium";
+        public static final String lightsOverlayAstropolisGammaLarge = "boggled_lights_overlay_astropolis_gamma_large";
+
+        public static final String lightsOverlayMiningSmall = "boggled_lights_overlay_mining_small";
+        public static final String lightsOverlayMiningMedium = "boggled_lights_overlay_mining_medium";
+        public static final String lightsOverlaySiphonSmall = "boggled_lights_overlay_siphon_small";
+        public static final String lightsOverlaySiphonMedium = "boggled_lights_overlay_siphon_medium";
+        public static final String alreadyReappliedLightsOverlay = "boggled_already_reapplied_lights_overlay";
+
+        public static final String miningStationSmall = "boggled_mining_station_small";
+        public static final String miningStationMedium = "boggled_mining_station_medium";
+
+        public static final String stationConstructionNumExpansionsOne = "boggled_station_construction_numExpansions_1";
+        public static final String stationConstructionNumExpansions = "boggled_station_construction_numExpansions_";
+    }
+
+    public static class BoggledSounds {
+        public static final String stationConstructed = "ui_boggled_station_constructed";
+    }
+
+    public static class BoggledCommodities {
+        public static final String domainArtifacts = "domain_artifacts";
+    }
+
+    public static class BoggledEntities {
+
+    }
+
+    public static class BoggledIndustries {
+        public static final String atmosphereProcessorIndustryID = "BOGGLED_ATMOSPHERE_PROCESSOR";
+        public static final String genelabIndustryID = "BOGGLED_GENELAB";
+        public static final String ismaraSlingIndustryID = "BOGGLED_ISMARA_SLING";
+    }
+
+    private static final String starPlanetID = "star";
+
+    private static final String aridPlanetID = "arid";
+    private static final String barrenPlanetID = "barren";
+    private static final String desertPlanetID = "desert";
+    private static final String frozenPlanetID = "frozen";
+    private static final String gasGiantPlanetID = "gas_giant";
+    private static final String junglePlanetID = "jungle";
+    private static final String terranPlanetID = "terran";
+    private static final String toxicPlanetID = "toxic";
+    private static final String tundraPlanetID = "tundra";
+    private static final String volcanicPlanetID = "volcanic";
+    private static final String waterPlanetID = "water";
+
+    private static final String unknownPlanetID = "unknown";
+
+    public static final String terraformingControllerConditionID = "terraforming_controller";
+    private static final String spriteControllerConditionID = "sprite_controller";
+    private static final String crampedQuartersConditionID = "cramped_quarters";
+
     // A mistyped string compiles fine and leads to plenty of debugging. A mistyped constant gives an error.
     private static final String colonyNotJungleWorld = "Colony is not already a jungle world";
     private static final String colonyNotAridWorld = "Colony is not already an arid world";
@@ -94,25 +202,27 @@ public class boggledTools
 
     private static final String colonyHasOrbitalWorksWPristineNanoforge = "Colony has orbital works with a pristine nanoforge";
 
-    private static final String jungleTypeChangeProjectID = "jungleTypeChange";
-    private static final String aridTypeChangeProjectID = "aridTypeChange";
-    private static final String terranTypeChangeProjectID = "terranTypeChange";
-    private static final String waterTypeChangeProjectID = "waterTypeChange";
-    private static final String tundraTypeChangeProjectID = "tundraTypeChange";
-    private static final String frozenTypeChangeProjectID = "frozenTypeChange";
+    public static final String noneProjectID = "None";
 
-    private static final String farmlandResourceImprovementProjectID = "farmlandResourceImprovement";
-    private static final String organicsResourceImprovementProjectID = "organicsResourceImprovement";
-    private static final String volatilesResourceImprovementProjectID = "volatilesResourceImprovement";
+    public static final String aridTypeChangeProjectID = "aridTypeChange";
+    public static final String frozenTypeChangeProjectID = "frozenTypeChange";
+    public static final String jungleTypeChangeProjectID = "jungleTypeChange";
+    public static final String terranTypeChangeProjectID = "terranTypeChange";
+    public static final String tundraTypeChangeProjectID = "tundraTypeChange";
+    public static final String waterTypeChangeProjectID = "waterTypeChange";
 
-    private static final String extremeWeatherConditionImprovementProjectID = "extremeWeatherConditionImprovement";
-    private static final String mildClimateConditionImprovementProjectID = "mildClimateConditionImprovement";
-    private static final String habitableConditionImprovementProjectID = "habitableConditionImprovement";
-    private static final String atmosphereDensityConditionImprovementProjectID = "atmosphereDensityConditionImprovement";
-    private static final String toxicAtmosphereConditionImprovementProjectID = "toxicAtmosphereConditionImprovement";
-    private static final String irradiatedConditionImprovementProjectID = "irradiatedConditionImprovement";
-    private static final String radiationConditionImprovementProjectID = "irradiatedConditionImprovement";
-    private static final String removeAtmosphereConditionImprovementProjectID = "removeAtmosphereConditionImprovement";
+    public static final String farmlandResourceImprovementProjectID = "farmlandResourceImprovement";
+    public static final String organicsResourceImprovementProjectID = "organicsResourceImprovement";
+    public static final String volatilesResourceImprovementProjectID = "volatilesResourceImprovement";
+
+    public static final String extremeWeatherConditionImprovementProjectID = "extremeWeatherConditionImprovement";
+    public static final String mildClimateConditionImprovementProjectID = "mildClimateConditionImprovement";
+    public static final String habitableConditionImprovementProjectID = "habitableConditionImprovement";
+    public static final String atmosphereDensityConditionImprovementProjectID = "atmosphereDensityConditionImprovement";
+    public static final String toxicAtmosphereConditionImprovementProjectID = "toxicAtmosphereConditionImprovement";
+    public static final String irradiatedConditionImprovementProjectID = "irradiatedConditionImprovement";
+    public static final String radiationConditionImprovementProjectID = "irradiatedConditionImprovement";
+    public static final String removeAtmosphereConditionImprovementProjectID = "removeAtmosphereConditionImprovement";
 
     private static final String aotd_TypeChangeResearchRequirement = "Researched: Terraforming Templates";
     private static final String aotd_ConditionImprovementResearchRequirement = "Researched : Atmosphere Manipulation";
@@ -406,9 +516,170 @@ public class boggledTools
         return ret;
     }
 
+    private static HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> initialisePlanetTypeChangeConditions() {
+        // one is conditions added, two is conditions removed
+        HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> ret = new HashMap<>();
+
+        ArrayList<String> jungleConditionsAdded = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.ORGANICS_COMMON
+        ));
+        ArrayList<String> jungleConditionsRemoved = new ArrayList<>(asList(
+                Conditions.WATER_SURFACE,
+                Conditions.VOLTURNIAN_LOBSTER_PENS,
+
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_TRACE,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_TRACE,
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_ABUNDANT,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        ArrayList<String> aridConditionsAdded = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.ORGANICS_COMMON
+        ));
+        ArrayList<String> aridConditionsRemoved = new ArrayList<>(asList(
+                Conditions.WATER_SURFACE,
+                Conditions.VOLTURNIAN_LOBSTER_PENS,
+
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_TRACE,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_TRACE,
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_ABUNDANT,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        ArrayList<String> terranConditionsAdded = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.ORGANICS_TRACE
+        ));
+        ArrayList<String> terranConditionsRemoved = new ArrayList<>(asList(
+                Conditions.WATER_SURFACE,
+                Conditions.VOLTURNIAN_LOBSTER_PENS,
+
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_COMMON,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_ABUNDANT,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        ArrayList<String> waterConditionsAdded = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.WATER_SURFACE
+        ));
+        ArrayList<String> waterConditionsRemoved = new ArrayList<>(asList(
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_TRACE,
+                Conditions.ORGANICS_COMMON,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_TRACE,
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_ABUNDANT,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        ArrayList<String> tundraConditionsAdded = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.ORGANICS_TRACE
+        ));
+        ArrayList<String> tundraConditionsRemoved = new ArrayList<>(asList(
+                Conditions.WATER_SURFACE,
+                Conditions.VOLTURNIAN_LOBSTER_PENS,
+
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_COMMON,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_ABUNDANT,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        ArrayList<String> frozenConditionsAdded = new ArrayList<>(asList(
+                Conditions.VOLATILES_ABUNDANT
+        ));
+        ArrayList<String> frozenConditionsRemoved = new ArrayList<>(asList(
+                Conditions.HABITABLE,
+                Conditions.WATER_SURFACE,
+                Conditions.VOLTURNIAN_LOBSTER_PENS,
+
+                Conditions.FARMLAND_POOR,
+                Conditions.FARMLAND_ADEQUATE,
+                Conditions.FARMLAND_RICH,
+                Conditions.FARMLAND_BOUNTIFUL,
+
+                Conditions.ORGANICS_TRACE,
+                Conditions.ORGANICS_COMMON,
+                Conditions.ORGANICS_ABUNDANT,
+                Conditions.ORGANICS_PLENTIFUL,
+
+                Conditions.VOLATILES_TRACE,
+                Conditions.VOLATILES_DIFFUSE,
+                Conditions.VOLATILES_PLENTIFUL
+        ));
+
+        if (boggledTools.getBooleanSetting(BoggledSettings.terraformingTypeChangeAddVolatiles)) {
+            terranConditionsAdded.add(Conditions.VOLATILES_TRACE);
+            tundraConditionsAdded.add(Conditions.VOLATILES_TRACE);
+        } else {
+            terranConditionsRemoved.add(Conditions.VOLATILES_TRACE);
+            tundraConditionsRemoved.add(Conditions.VOLATILES_TRACE);
+        }
+
+        // Modded conditions get added here, do the mod enabled check and throw them in the appropriate list
+
+        ret.put(jungleTypeChangeProjectID, new Pair<>(jungleConditionsAdded, jungleConditionsRemoved));
+        ret.put(aridTypeChangeProjectID, new Pair<>(aridConditionsAdded, aridConditionsRemoved));
+        ret.put(terranTypeChangeProjectID, new Pair<>(terranConditionsAdded, terranConditionsRemoved));
+        ret.put(waterTypeChangeProjectID, new Pair<>(waterConditionsAdded, waterConditionsRemoved));
+        ret.put(tundraTypeChangeProjectID, new Pair<>(tundraConditionsAdded, tundraConditionsRemoved));
+        ret.put(frozenTypeChangeProjectID, new Pair<>(frozenConditionsAdded, frozenConditionsRemoved));
+
+        return ret;
+    }
+
     private static final HashMap<String, String[]> projectRequirements = initialiseProjectRequirements();
 
     private static final HashMap<String, String> projectTooltip = initialiseProjectTooltips();
+
+    // one is conditions added, two is conditions removed
+    private static final HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> planetTypeChangeConditions = initialisePlanetTypeChangeConditions();
 
     public static float getDistanceBetweenPoints(float x1, float y1, float x2, float y2) {
         return (float) Math.sqrt((y2 - y1) * (y2 - y1) + (x2 - x1) * (x2 - x1));
@@ -459,7 +730,7 @@ public class boggledTools
     public static boolean gateInSystem(StarSystemAPI system)
     {
         for (SectorEntityToken entity : system.getAllEntities()) {
-            if (entity.hasTag("gate")) {
+            if (entity.hasTag(Tags.GATE)) {
                 return true;
             }
         }
@@ -494,7 +765,7 @@ public class boggledTools
 
     public static Integer getPlayerMarketSizeRequirementToBuildGate()
     {
-        return boggledTools.getIntSetting("boggledMarketSizeRequiredToBuildInactiveGate");
+        return boggledTools.getIntSetting(BoggledSettings.marketSizeRequiredToBuildInactiveGate);
     }
 
     public static SectorEntityToken getClosestPlayerMarketToken(SectorEntityToken playerFleet) {
@@ -559,7 +830,7 @@ public class boggledTools
 
     public static boolean colonizableStationInSystem(SectorEntityToken playerFleet) {
         for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
-            if (entity.hasTag("station") && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
+            if (entity.hasTag(Tags.STATION) && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
                 return true;
             }
         }
@@ -574,7 +845,7 @@ public class boggledTools
             ArrayList<SectorEntityToken> allColonizableStationsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
-                if (entity.hasTag("station") && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
+                if (entity.hasTag(Tags.STATION) && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
                     allColonizableStationsInSystem.add(entity);
                 }
             }
@@ -594,7 +865,7 @@ public class boggledTools
 
     public static boolean stationInSystem(SectorEntityToken playerFleet) {
         for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
-            if (entity.hasTag("station")) {
+            if (entity.hasTag(Tags.STATION)) {
                 return true;
             }
         }
@@ -609,7 +880,7 @@ public class boggledTools
             ArrayList<SectorEntityToken> allStationsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
-                if (entity.hasTag("station")) {
+                if (entity.hasTag(Tags.STATION)) {
                     allStationsInSystem.add(entity);
                 }
             }
@@ -659,7 +930,7 @@ public class boggledTools
 
     public static boolean planetInSystem(SectorEntityToken playerFleet) {
         for (SectorEntityToken planet : playerFleet.getStarSystem().getAllEntities()) {
-            if (planet instanceof PlanetAPI && !getPlanetType(((PlanetAPI) planet)).equals("star")) {
+            if (planet instanceof PlanetAPI && !getPlanetType(((PlanetAPI) planet)).equals(starPlanetID)) {
                 return true;
             }
         }
@@ -678,7 +949,7 @@ public class boggledTools
             ArrayList<SectorEntityToken> allPlanetsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
-                if (entity instanceof PlanetAPI && !getPlanetType(((PlanetAPI) entity)).equals("star")) {
+                if (entity instanceof PlanetAPI && !getPlanetType(((PlanetAPI) entity)).equals(starPlanetID)) {
                     allPlanetsInSystem.add(entity);
                 }
             }
@@ -709,7 +980,7 @@ public class boggledTools
         {
             if(closestMarket == null || getDistanceBetweenTokens(entity, market.getPrimaryEntity()) < getDistanceBetweenTokens(entity, closestMarket.getPrimaryEntity()))
             {
-                if(!market.getFactionId().equals("neutral"))
+                if(!market.getFactionId().equals(Factions.NEUTRAL))
                 {
                     closestMarket = market;
                 }
@@ -726,13 +997,13 @@ public class boggledTools
 
         if(planet == null || planet.getSpec() == null || planet.getSpec().getPlanetType() == null)
         {
-            return "unknown";
+            return unknownPlanetID;
         }
 
         // Added this to catch Unknown Skies planets or other modded planet types
-        if(planet.getMarket() != null && planet.getMarket().hasCondition("water_surface"))
+        if(planet.getMarket() != null && planet.getMarket().hasCondition(Conditions.WATER_SURFACE))
         {
-            return "water";
+            return waterPlanetID;
         }
 
         String planetType = planet.getTypeId();
@@ -770,7 +1041,7 @@ public class boggledTools
             case "vayra_star_blue":
             case "vayra_star_brown":
             case "vayra_star_yellow_white":
-                return "star";
+                return starPlanetID;
             case "gas_giant":
             case "ice_giant":
             case "US_gas_giant":
@@ -778,7 +1049,7 @@ public class boggledTools
             case "fds_gas_giant":
             case "SCY_tartarus":
             case "galaxytigers_gas_giant":
-                return "gas_giant";
+                return gasGiantPlanetID;
             case "barren":
             case "barren_castiron":
             case "barren2":
@@ -810,12 +1081,12 @@ public class boggledTools
             case "rad_planet":
             case "ecumenopolis":
             case "nskr_ice_desert":
-                return "barren";
+                return barrenPlanetID;
             case "toxic":
             case "toxic_cold":
             case "US_green":
             case "SCY_acid":
-                return "toxic";
+                return toxicPlanetID;
             case "desert":
             case "desert1":
             case "arid":
@@ -836,7 +1107,7 @@ public class boggledTools
             case "vayra_bread":
             case "US_auric":
             case "US_auricCloudy":
-                return "desert";
+                return desertPlanetID;
             case "terran":
             case "terran-eccentric":
             case "US_lifeless":
@@ -846,18 +1117,18 @@ public class boggledTools
             case "US_water":
             case "US_waterB":
             case "terran_adapted":
-                return "terran";
+                return terranPlanetID;
             case "water":
-                return "water";
+                return waterPlanetID;
             case "tundra":
             case "US_purple":
             case "fds_tundra":
             case "galaxytigers_tundra":
-                return "tundra";
+                return tundraPlanetID;
             case "jungle":
             case "US_jungle":
             case "jungle_charkha":
-                return "jungle";
+                return junglePlanetID;
             case "frozen":
             case "frozen1":
             case "frozen2":
@@ -868,15 +1139,15 @@ public class boggledTools
             case "US_blue":
             case "fds_cryovolcanic":
             case "fds_frozen":
-                return "frozen";
+                return frozenPlanetID;
             case "lava":
             case "lava_minor":
             case "US_lava":
             case "US_volcanic":
             case "fds_lava":
-                return "volcanic";
+                return volcanicPlanetID;
             default:
-                return "unknown";
+                return unknownPlanetID;
         }
     }
 
@@ -888,9 +1159,9 @@ public class boggledTools
         {
             if(!boggledTools.marketIsStation(market))
             {
-                if(!market.hasCondition("terraforming_controller"))
+                if(!market.hasCondition(terraformingControllerConditionID))
                 {
-                    boggledTools.addCondition(market, "terraforming_controller");
+                    boggledTools.addCondition(market, terraformingControllerConditionID);
                 }
                 allNonStationPlayerMarkets.add(market);
             }
@@ -900,7 +1171,7 @@ public class boggledTools
     }
 
     public static boolean marketIsStation(MarketAPI market) {
-        return market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.getPrimaryEntity().hasTag("station");
+        return market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.getPrimaryEntity().hasTag(Tags.STATION);
     }
 
     public static boolean terraformingPossibleOnMarket(MarketAPI market) {
@@ -908,27 +1179,27 @@ public class boggledTools
             return false;
         }
 
-        if (market.hasCondition("irradiated")) {
+        if (market.hasCondition(Conditions.IRRADIATED)) {
             return false;
         }
 
         String planetType = boggledTools.getPlanetType(market.getPlanetEntity());
-        return !planetType.equals("star") && !planetType.equals("gas_giant") && !planetType.equals("volcanic") && !planetType.equals("unknown");
+        return !planetType.equals(starPlanetID) && !planetType.equals(gasGiantPlanetID) && !planetType.equals(volcanicPlanetID) && !planetType.equals(unknownPlanetID);
     }
 
     public static boolean getCreateMirrorsOrShades(MarketAPI market) {
         // Return true for mirrors, false for shades
         // Go by temperature first. If not triggered, will check planet type. Otherwise, just return true.
 
-        if (market.hasCondition("poor_light") || market.hasCondition("very_cold") || market.hasCondition("cold")) {
+        if (market.hasCondition(Conditions.POOR_LIGHT) || market.hasCondition(Conditions.VERY_COLD) || market.hasCondition(Conditions.COLD)) {
             return true;
-        } else if (market.hasCondition("very_hot") || market.hasCondition("hot")) {
+        } else if (market.hasCondition(Conditions.VERY_HOT) || market.hasCondition(Conditions.HOT)) {
             return false;
         }
 
-        if (boggledTools.getPlanetType(market.getPlanetEntity()).equals("desert") || boggledTools.getPlanetType(market.getPlanetEntity()).equals("jungle")) {
+        if (boggledTools.getPlanetType(market.getPlanetEntity()).equals(desertPlanetID) || boggledTools.getPlanetType(market.getPlanetEntity()).equals(junglePlanetID)) {
             return false;
-        } else if (boggledTools.getPlanetType(market.getPlanetEntity()).equals("tundra") || boggledTools.getPlanetType(market.getPlanetEntity()).equals("frozen")) {
+        } else if (boggledTools.getPlanetType(market.getPlanetEntity()).equals(tundraPlanetID) || boggledTools.getPlanetType(market.getPlanetEntity()).equals(frozenPlanetID)) {
             return true;
         }
 
@@ -1074,18 +1345,18 @@ public class boggledTools
     }
 
     public static String getMiningStationResourceString(Integer numAsteroidTerrains) {
-        if (numAsteroidTerrains >= boggledTools.getIntSetting("boggledMiningStationUltrarichOre")) {
+        if (numAsteroidTerrains >= boggledTools.getIntSetting(BoggledSettings.miningStationUltrarichOre)) {
             return "ultrarich";
         }
-        if (numAsteroidTerrains >= boggledTools.getIntSetting("boggledMiningStationRichOre")) {
+        if (numAsteroidTerrains >= boggledTools.getIntSetting(BoggledSettings.miningStationRichOre)) {
             return "rich";
         }
-        if (numAsteroidTerrains >= boggledTools.getIntSetting("boggledMiningStationAbundantOre")) {
+        if (numAsteroidTerrains >= boggledTools.getIntSetting(BoggledSettings.miningStationAbundantOre)) {
             return "abundant";
         }
-        if (numAsteroidTerrains >= boggledTools.getIntSetting("boggledMiningStationModerateOre")) {
+        if (numAsteroidTerrains >= boggledTools.getIntSetting(BoggledSettings.miningStationModerateOre)) {
             return "moderate";
-        } else if (numAsteroidTerrains >= boggledTools.getIntSetting("boggledMiningStationSparseOre")) {
+        } else if (numAsteroidTerrains >= boggledTools.getIntSetting(BoggledSettings.miningStationSparseOre)) {
             return "sparse";
         } else {
             return "abundant";
@@ -1094,7 +1365,7 @@ public class boggledTools
 
     public static int getNumberOfStationExpansions(MarketAPI market) {
         for (String tag : market.getTags()) {
-            if (tag.contains("boggled_station_construction_numExpansions_")) {
+            if (tag.contains(BoggledTags.stationConstructionNumExpansions)) {
                 return Integer.parseInt(tag.substring(tag.length() - 1));
             }
         }
@@ -1104,11 +1375,11 @@ public class boggledTools
 
     public static void incrementNumberOfStationExpansions(MarketAPI market) {
         if (getNumberOfStationExpansions(market) == 0) {
-            market.addTag("boggled_station_construction_numExpansions_1");
+            market.addTag(BoggledTags.stationConstructionNumExpansionsOne);
         } else {
             int numExpansionsOld = getNumberOfStationExpansions(market);
-            market.removeTag("boggled_station_construction_numExpansions_" + numExpansionsOld);
-            market.addTag("boggled_station_construction_numExpansions_" + (numExpansionsOld + 1));
+            market.removeTag(BoggledTags.stationConstructionNumExpansions + numExpansionsOld);
+            market.addTag(BoggledTags.stationConstructionNumExpansions + (numExpansionsOld + 1));
         }
     }
 
@@ -1125,19 +1396,19 @@ public class boggledTools
 
     public static void refreshAquacultureAndFarming(MarketAPI market)
     {
-        if(market == null || market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.hasTag("station") || market.getPrimaryEntity().hasTag("station"))
+        if(market == null || market.getPrimaryEntity() == null || market.getPlanetEntity() == null || market.hasTag(Tags.STATION) || market.getPrimaryEntity().hasTag(Tags.STATION))
         {
             return;
         }
         else
         {
-            if(market.hasIndustry("farming") && market.hasCondition("water_surface"))
+            if(market.hasIndustry(Industries.FARMING) && market.hasCondition(Conditions.WATER_SURFACE))
             {
-                market.getIndustry("farming").init("aquaculture", market);
+                market.getIndustry(Industries.FARMING).init(Industries.AQUACULTURE, market);
             }
-            else if(market.hasIndustry("aquaculture") && !market.hasCondition("water_surface"))
+            else if(market.hasIndustry(Industries.AQUACULTURE) && !market.hasCondition(Conditions.WATER_SURFACE))
             {
-                market.getIndustry("aquaculture").init("farming", market);
+                market.getIndustry(Industries.AQUACULTURE).init(Industries.FARMING, market);
             }
         }
     }
@@ -1151,7 +1422,7 @@ public class boggledTools
     {
         SectorEntityToken targetEntityToRemove = null;
         for (SectorEntityToken entity : market.getConnectedEntities()) {
-            if (entity instanceof PlanetAPI && !entity.hasTag("station")) {
+            if (entity instanceof PlanetAPI && !entity.hasTag(Tags.STATION)) {
                 targetEntityToRemove = entity;
             }
         }
@@ -1167,7 +1438,7 @@ public class boggledTools
     {
         SectorEntityToken targetEntityToRemove = null;
         for (SectorEntityToken entity : market.getConnectedEntities()) {
-            if (entity.hasTag("station")) {
+            if (entity.hasTag(Tags.STATION)) {
                 targetEntityToRemove = entity;
             }
         }
@@ -1184,7 +1455,7 @@ public class boggledTools
         int numReflectors = 0;
 
         for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.getId().contains("stellar_shade") || entity.hasTag("stellar_mirror") || entity.hasTag("stellar_shade"))) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains(Entities.STELLAR_MIRROR) || entity.getId().contains(Entities.STELLAR_SHADE) || entity.hasTag(Entities.STELLAR_MIRROR) || entity.hasTag(Entities.STELLAR_SHADE))) {
                 numReflectors++;
             }
         }
@@ -1197,7 +1468,7 @@ public class boggledTools
         int numMirrors = 0;
 
         for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.hasTag("stellar_mirror"))) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains(Entities.STELLAR_MIRROR) || entity.hasTag(Entities.STELLAR_MIRROR))) {
                 numMirrors++;
             }
         }
@@ -1210,7 +1481,7 @@ public class boggledTools
         int numShades = 0;
 
         for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_shade") || entity.hasTag("stellar_shade"))) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains(Entities.STELLAR_SHADE) || entity.hasTag(Entities.STELLAR_SHADE))) {
                 numShades++;
             }
         }
@@ -1224,7 +1495,7 @@ public class boggledTools
         while(allEntitiesInSystem.hasNext())
         {
             SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains("stellar_mirror") || entity.getId().contains("stellar_shade") || entity.hasTag("stellar_mirror") || entity.hasTag("stellar_shade")))
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains(Entities.STELLAR_MIRROR) || entity.getId().contains(Entities.STELLAR_SHADE) || entity.hasTag(Entities.STELLAR_MIRROR) || entity.hasTag(Entities.STELLAR_SHADE)))
             {
                 allEntitiesInSystem.remove();
                 market.getStarSystem().removeEntity(entity);
@@ -1235,7 +1506,7 @@ public class boggledTools
     public static boolean hasIsmaraSling(MarketAPI market)
     {
         for (MarketAPI marketElement : Global.getSector().getEconomy().getMarkets(market.getStarSystem())) {
-            if (marketElement.getFactionId().equals(market.getFactionId()) && marketElement.hasIndustry("BOGGLED_ISMARA_SLING") && marketElement.getIndustry("BOGGLED_ISMARA_SLING").isFunctional()) {
+            if (marketElement.getFactionId().equals(market.getFactionId()) && marketElement.hasIndustry(BoggledIndustries.ismaraSlingIndustryID) && marketElement.getIndustry(BoggledIndustries.ismaraSlingIndustryID).isFunctional()) {
                 return true;
             }
         }
@@ -1341,7 +1612,7 @@ public class boggledTools
 
         // Handle Illustrated Entities custom images and/or description.
         // TASC uses classes from the Illustrated Entities to do this - the Illustrated Entities JAR is imported as a library into TASC.
-        if(Global.getSettings().getModManager().isModEnabled("illustrated_entities"))
+        if(Global.getSettings().getModManager().isModEnabled(BoggledMods.illustratedEntitiesModID))
         {
             boolean customImageHasBeenSet = ImageHandler.hasImage(station);
             if(customImageHasBeenSet)
@@ -1407,7 +1678,7 @@ public class boggledTools
                 switch (stationGreekLetter) {
                     case "alpha": {
                         for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_alpha_small") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_medium") || entity.hasTag("boggled_lights_overlay_astropolis_alpha_large"))) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaLarge))) {
                                 targetTokenToDelete = entity;
                                 break;
                             }
@@ -1421,7 +1692,7 @@ public class boggledTools
                     }
                     case "beta": {
                         for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_beta_small") || entity.hasTag("boggled_lights_overlay_astropolis_beta_medium") || entity.hasTag("boggled_lights_overlay_astropolis_beta_large"))) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaLarge))) {
                                 targetTokenToDelete = entity;
                                 break;
                             }
@@ -1435,7 +1706,7 @@ public class boggledTools
                     }
                     case "gamma": {
                         for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag("boggled_lights_overlay_astropolis_gamma_small") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_medium") || entity.hasTag("boggled_lights_overlay_astropolis_gamma_large"))) {
+                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaLarge))) {
                                 targetTokenToDelete = entity;
                                 break;
                             }
@@ -1454,7 +1725,7 @@ public class boggledTools
                 SectorEntityToken targetTokenToDelete = null;
 
                 for (SectorEntityToken entity : system.getAllEntities()) {
-                    if (entity.hasTag("boggled_lights_overlay_mining_small") || entity.hasTag("boggled_lights_overlay_mining_medium")) {
+                    if (entity.hasTag(BoggledTags.lightsOverlayMiningSmall) || entity.hasTag(BoggledTags.lightsOverlayMiningMedium)) {
                         targetTokenToDelete = entity;
                         break;
                     }
@@ -1470,7 +1741,7 @@ public class boggledTools
                 SectorEntityToken targetTokenToDelete = null;
 
                 for (SectorEntityToken entity : system.getAllEntities()) {
-                    if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && (entity.hasTag("boggled_lights_overlay_siphon_small") || entity.hasTag("boggled_lights_overlay_siphon_medium"))) {
+                    if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && (entity.hasTag(BoggledTags.lightsOverlaySiphonSmall) || entity.hasTag(BoggledTags.lightsOverlaySiphonMedium))) {
                         targetTokenToDelete = entity;
                         break;
                     }
@@ -1494,15 +1765,15 @@ public class boggledTools
         int stationsize = 0;
 
         for (SectorEntityToken entity : system.getAllEntities()) {
-            if (entity.hasTag("boggled_mining_station_small") && !entity.hasTag("boggled_already_reapplied_lights_overlay")) {
+            if (entity.hasTag(BoggledTags.miningStationSmall) && !entity.hasTag(BoggledTags.alreadyReappliedLightsOverlay)) {
                 stationToApplyOverlayTo = entity;
                 stationsize = 1;
-                entity.addTag("boggled_already_reapplied_lights_overlay");
+                entity.addTag(BoggledTags.alreadyReappliedLightsOverlay);
                 break;
-            } else if (entity.hasTag("boggled_mining_station_medium") && !entity.hasTag("boggled_already_reapplied_lights_overlay")) {
+            } else if (entity.hasTag(BoggledTags.miningStationMedium) && !entity.hasTag(BoggledTags.alreadyReappliedLightsOverlay)) {
                 stationToApplyOverlayTo = entity;
                 stationsize = 2;
-                entity.addTag("boggled_already_reapplied_lights_overlay");
+                entity.addTag(BoggledTags.alreadyReappliedLightsOverlay);
                 break;
             }
         }
@@ -1511,7 +1782,7 @@ public class boggledTools
         {
             if(stationsize == 1)
             {
-                if(!stationToApplyOverlayTo.getMarket().getFactionId().equals("neutral"))
+                if(!stationToApplyOverlayTo.getMarket().getFactionId().equals(Factions.NEUTRAL))
                 {
                     SectorEntityToken newMiningStationLights = system.addCustomEntity("boggled_miningStationLights", "Mining Station Lights Overlay", "boggled_mining_station_small_lights_overlay", stationToApplyOverlayTo.getFaction().getId());
                     newMiningStationLights.setOrbit(stationToApplyOverlayTo.getOrbit().makeCopy());
@@ -1531,8 +1802,8 @@ public class boggledTools
         else
         {
             for (SectorEntityToken entity : system.getAllEntities()) {
-                if (entity.hasTag("boggled_already_reapplied_lights_overlay")) {
-                    entity.removeTag("boggled_already_reapplied_lights_overlay");
+                if (entity.hasTag(BoggledTags.alreadyReappliedLightsOverlay)) {
+                    entity.removeTag(BoggledTags.alreadyReappliedLightsOverlay);
                 }
             }
         }
@@ -1541,7 +1812,7 @@ public class boggledTools
     public static boolean marketHasOrbitalStation(MarketAPI market)
     {
         for (SectorEntityToken entity : market.getStarSystem().getAllEntities()) {
-            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && entity.hasTag("station")) {
+            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && entity.hasTag(Tags.STATION)) {
                 return true;
             }
         }
@@ -1556,11 +1827,11 @@ public class boggledTools
 
         PlanetAPI planet = market.getPlanetEntity();
 
-        if(getPlanetType(planet).equals("star") || getPlanetType(planet).equals("gas_giant") || getPlanetType(planet).equals("barren") || getPlanetType(planet).equals("toxic") || getPlanetType(planet).equals("volcanic") || getPlanetType(planet).equals("frozen") || getPlanetType(planet).equals("water") || getPlanetType(planet).equals("unknown"))
+        if(getPlanetType(planet).equals(starPlanetID) || getPlanetType(planet).equals(gasGiantPlanetID) || getPlanetType(planet).equals(barrenPlanetID) || getPlanetType(planet).equals(toxicPlanetID) || getPlanetType(planet).equals(volcanicPlanetID) || getPlanetType(planet).equals(frozenPlanetID) || getPlanetType(planet).equals(waterPlanetID) || getPlanetType(planet).equals(unknownPlanetID))
         {
             return 0;
         }
-        else if(getPlanetType(planet).equals("jungle") || getPlanetType(planet).equals("desert") || getPlanetType(planet).equals("terran") || getPlanetType(planet).equals("tundra"))
+        else if(getPlanetType(planet).equals(junglePlanetID) || getPlanetType(planet).equals(desertPlanetID) || getPlanetType(planet).equals(terranPlanetID) || getPlanetType(planet).equals(tundraPlanetID))
         {
             return 4;
         }
@@ -1575,19 +1846,19 @@ public class boggledTools
         // Returns 0 if the planet has no farmland
         // Returns 1 through 4 for the levels of farmland, with 1 being poor and 4 being bountiful
 
-        if(market.hasCondition("farmland_poor"))
+        if(market.hasCondition(Conditions.FARMLAND_POOR))
         {
             return 1;
         }
-        else if(market.hasCondition("farmland_adequate"))
+        else if(market.hasCondition(Conditions.FARMLAND_ADEQUATE))
         {
             return 2;
         }
-        else if(market.hasCondition("farmland_rich"))
+        else if(market.hasCondition(Conditions.FARMLAND_RICH))
         {
             return 3;
         }
-        else if(market.hasCondition("farmland_bountiful"))
+        else if(market.hasCondition(Conditions.FARMLAND_BOUNTIFUL))
         {
             return 4;
         }
@@ -1604,19 +1875,19 @@ public class boggledTools
 
         PlanetAPI planet = market.getPlanetEntity();
 
-        if(getPlanetType(planet).equals("star") || getPlanetType(planet).equals("gas_giant") || getPlanetType(planet).equals("barren") || getPlanetType(planet).equals("toxic") || getPlanetType(planet).equals("volcanic") || getPlanetType(planet).equals("frozen") || getPlanetType(planet).equals("unknown"))
+        if(getPlanetType(planet).equals(starPlanetID) || getPlanetType(planet).equals(gasGiantPlanetID) || getPlanetType(planet).equals(barrenPlanetID) || getPlanetType(planet).equals(toxicPlanetID) || getPlanetType(planet).equals(volcanicPlanetID) || getPlanetType(planet).equals(frozenPlanetID) || getPlanetType(planet).equals(unknownPlanetID))
         {
             return 0;
         }
-        else if(getPlanetType(planet).equals("water") || getPlanetType(planet).equals("jungle") || getPlanetType(planet).equals("terran"))
+        else if(getPlanetType(planet).equals(waterPlanetID) || getPlanetType(planet).equals(junglePlanetID) || getPlanetType(planet).equals(terranPlanetID))
         {
             return 4;
         }
-        else if(getPlanetType(planet).equals("desert"))
+        else if(getPlanetType(planet).equals(desertPlanetID))
         {
             return 3;
         }
-        else if(getPlanetType(planet).equals("tundra"))
+        else if(getPlanetType(planet).equals(tundraPlanetID))
         {
             return 1;
         }
@@ -1631,19 +1902,19 @@ public class boggledTools
         // Returns 0 if the planet has no organics
         // Returns 1 through 4 for the levels of organics, with 1 being trace and 4 being plentiful
 
-        if(market.hasCondition("organics_trace"))
+        if(market.hasCondition(Conditions.ORGANICS_TRACE))
         {
             return 1;
         }
-        else if(market.hasCondition("organics_common"))
+        else if(market.hasCondition(Conditions.ORGANICS_COMMON))
         {
             return 2;
         }
-        else if(market.hasCondition("organics_abundant"))
+        else if(market.hasCondition(Conditions.ORGANICS_ABUNDANT))
         {
             return 3;
         }
-        else if(market.hasCondition("organics_plentiful"))
+        else if(market.hasCondition(Conditions.ORGANICS_PLENTIFUL))
         {
             return 4;
         }
@@ -1660,15 +1931,15 @@ public class boggledTools
 
         PlanetAPI planet = market.getPlanetEntity();
 
-        if(getPlanetType(planet).equals("star") || getPlanetType(planet).equals("gas_giant") || getPlanetType(planet).equals("barren") || getPlanetType(planet).equals("toxic") || getPlanetType(planet).equals("volcanic") || getPlanetType(planet).equals("jungle") || getPlanetType(planet).equals("unknown"))
+        if(getPlanetType(planet).equals(starPlanetID) || getPlanetType(planet).equals(gasGiantPlanetID) || getPlanetType(planet).equals(barrenPlanetID) || getPlanetType(planet).equals(toxicPlanetID) || getPlanetType(planet).equals(volcanicPlanetID) || getPlanetType(planet).equals(junglePlanetID) || getPlanetType(planet).equals(unknownPlanetID))
         {
             return 0;
         }
-        else if(getPlanetType(planet).equals("frozen") || getPlanetType(planet).equals("tundra") || getPlanetType(planet).equals("water"))
+        else if(getPlanetType(planet).equals(frozenPlanetID) || getPlanetType(planet).equals(tundraPlanetID) || getPlanetType(planet).equals(waterPlanetID))
         {
             return 4;
         }
-        else if(getPlanetType(planet).equals("desert") || getPlanetType(planet).equals("terran"))
+        else if(getPlanetType(planet).equals(desertPlanetID) || getPlanetType(planet).equals(terranPlanetID))
         {
             return 1;
         }
@@ -1683,19 +1954,19 @@ public class boggledTools
         // Returns 0 if the planet has no volatiles
         // Returns 1 through 4 for the levels of volatiles, with 1 being trace and 4 being plentiful
 
-        if(market.hasCondition("volatiles_trace"))
+        if(market.hasCondition(Conditions.VOLATILES_TRACE))
         {
             return 1;
         }
-        else if(market.hasCondition("volatiles_diffuse"))
+        else if(market.hasCondition(Conditions.VOLATILES_DIFFUSE))
         {
             return 2;
         }
-        else if(market.hasCondition("volatiles_abundant"))
+        else if(market.hasCondition(Conditions.VOLATILES_ABUNDANT))
         {
             return 3;
         }
-        else if(market.hasCondition("volatiles_plentiful"))
+        else if(market.hasCondition(Conditions.VOLATILES_PLENTIFUL))
         {
             return 4;
         }
@@ -1707,28 +1978,28 @@ public class boggledTools
 
     public static void incrementFarmland(MarketAPI market)
     {
-        if(market.hasCondition("farmland_poor"))
+        if(market.hasCondition(Conditions.FARMLAND_POOR))
         {
-            boggledTools.removeCondition(market, "farmland_poor");
-            boggledTools.addCondition(market, "farmland_adequate");
+            boggledTools.removeCondition(market, Conditions.FARMLAND_POOR);
+            boggledTools.addCondition(market, Conditions.FARMLAND_ADEQUATE);
         }
-        else if(market.hasCondition("farmland_adequate"))
+        else if(market.hasCondition(Conditions.FARMLAND_ADEQUATE))
         {
-            boggledTools.removeCondition(market, "farmland_adequate");
-            boggledTools.addCondition(market, "farmland_rich");
+            boggledTools.removeCondition(market, Conditions.FARMLAND_ADEQUATE);
+            boggledTools.addCondition(market, Conditions.FARMLAND_RICH);
         }
-        else if(market.hasCondition("farmland_rich"))
+        else if(market.hasCondition(Conditions.FARMLAND_RICH))
         {
-            boggledTools.removeCondition(market, "farmland_rich");
-            boggledTools.addCondition(market, "farmland_bountiful");
+            boggledTools.removeCondition(market, Conditions.FARMLAND_RICH);
+            boggledTools.addCondition(market, Conditions.FARMLAND_BOUNTIFUL);
         }
-        else if(market.hasCondition("farmland_bountiful"))
+        else if(market.hasCondition(Conditions.FARMLAND_BOUNTIFUL))
         {
             //Do nothing
         }
         else
         {
-            boggledTools.addCondition(market, "farmland_poor");
+            boggledTools.addCondition(market, Conditions.FARMLAND_POOR);
         }
 
         boggledTools.surveyAll(market);
@@ -1747,28 +2018,28 @@ public class boggledTools
 
     public static void incrementOrganics(MarketAPI market)
     {
-        if(market.hasCondition("organics_trace"))
+        if(market.hasCondition(Conditions.ORGANICS_TRACE))
         {
-            boggledTools.removeCondition(market, "organics_trace");
-            boggledTools.addCondition(market, "organics_common");
+            boggledTools.removeCondition(market, Conditions.ORGANICS_TRACE);
+            boggledTools.addCondition(market, Conditions.ORGANICS_COMMON);
         }
-        else if(market.hasCondition("organics_common"))
+        else if(market.hasCondition(Conditions.ORGANICS_COMMON))
         {
-            boggledTools.removeCondition(market, "organics_common");
-            boggledTools.addCondition(market, "organics_abundant");
+            boggledTools.removeCondition(market, Conditions.ORGANICS_COMMON);
+            boggledTools.addCondition(market, Conditions.ORGANICS_ABUNDANT);
         }
-        else if(market.hasCondition("organics_abundant"))
+        else if(market.hasCondition(Conditions.ORGANICS_ABUNDANT))
         {
-            boggledTools.removeCondition(market, "organics_abundant");
-            boggledTools.addCondition(market, "organics_plentiful");
+            boggledTools.removeCondition(market, Conditions.ORGANICS_ABUNDANT);
+            boggledTools.addCondition(market, Conditions.ORGANICS_PLENTIFUL);
         }
-        else if(market.hasCondition("organics_plentiful"))
+        else if(market.hasCondition(Conditions.ORGANICS_PLENTIFUL))
         {
             //Do nothing
         }
         else
         {
-            boggledTools.addCondition(market, "organics_trace");
+            boggledTools.addCondition(market, Conditions.ORGANICS_TRACE);
         }
 
         boggledTools.surveyAll(market);
@@ -1787,28 +2058,28 @@ public class boggledTools
 
     public static void incrementVolatiles(MarketAPI market)
     {
-        if(market.hasCondition("volatiles_trace"))
+        if(market.hasCondition(Conditions.VOLATILES_TRACE))
         {
-            boggledTools.removeCondition(market, "volatiles_trace");
-            boggledTools.addCondition(market, "volatiles_diffuse");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_TRACE);
+            boggledTools.addCondition(market, Conditions.VOLATILES_DIFFUSE);
         }
-        else if(market.hasCondition("volatiles_diffuse"))
+        else if(market.hasCondition(Conditions.VOLATILES_DIFFUSE))
         {
-            boggledTools.removeCondition(market, "volatiles_diffuse");
-            boggledTools.addCondition(market, "volatiles_abundant");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_DIFFUSE);
+            boggledTools.addCondition(market, Conditions.VOLATILES_ABUNDANT);
         }
-        else if(market.hasCondition("volatiles_abundant"))
+        else if(market.hasCondition(Conditions.VOLATILES_ABUNDANT))
         {
-            boggledTools.removeCondition(market, "volatiles_abundant");
-            boggledTools.addCondition(market, "volatiles_plentiful");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_ABUNDANT);
+            boggledTools.addCondition(market, Conditions.VOLATILES_PLENTIFUL);
         }
-        else if(market.hasCondition("volatiles_plentiful"))
+        else if(market.hasCondition(Conditions.VOLATILES_PLENTIFUL))
         {
             //Do nothing
         }
         else
         {
-            boggledTools.addCondition(market, "volatiles_trace");
+            boggledTools.addCondition(market, Conditions.VOLATILES_TRACE);
         }
 
         boggledTools.surveyAll(market);
@@ -1827,62 +2098,62 @@ public class boggledTools
 
     public static void incrementOreForPlanetCracking(MarketAPI market)
     {
-        if(market.hasCondition("ore_sparse"))
+        if(market.hasCondition(Conditions.ORE_SPARSE))
         {
-            boggledTools.removeCondition(market, "ore_sparse");
-            boggledTools.addCondition(market, "ore_moderate");
+            boggledTools.removeCondition(market, Conditions.ORE_SPARSE);
+            boggledTools.addCondition(market, Conditions.ORE_MODERATE);
         }
-        else if(market.hasCondition("ore_moderate"))
+        else if(market.hasCondition(Conditions.ORE_MODERATE))
         {
-            boggledTools.removeCondition(market, "ore_moderate");
-            boggledTools.addCondition(market, "ore_abundant");
+            boggledTools.removeCondition(market, Conditions.ORE_MODERATE);
+            boggledTools.addCondition(market, Conditions.ORE_ABUNDANT);
         }
-        else if(market.hasCondition("ore_abundant"))
+        else if(market.hasCondition(Conditions.ORE_ABUNDANT))
         {
-            boggledTools.removeCondition(market, "ore_abundant");
-            boggledTools.addCondition(market, "ore_rich");
+            boggledTools.removeCondition(market, Conditions.ORE_ABUNDANT);
+            boggledTools.addCondition(market, Conditions.ORE_RICH);
         }
-        else if(market.hasCondition("ore_rich"))
+        else if(market.hasCondition(Conditions.ORE_RICH))
         {
-            boggledTools.removeCondition(market, "ore_rich");
-            boggledTools.addCondition(market, "ore_ultrarich");
+            boggledTools.removeCondition(market, Conditions.ORE_RICH);
+            boggledTools.addCondition(market, Conditions.ORE_ULTRARICH);
         }
-        else if(market.hasCondition("ore_ultrarich"))
+        else if(market.hasCondition(Conditions.ORE_ULTRARICH))
         {
             //Do Nothing
         }
         else
         {
-            boggledTools.addCondition(market, "ore_sparse");
+            boggledTools.addCondition(market, Conditions.ORE_SPARSE);
         }
 
-        if(market.hasCondition("rare_ore_sparse"))
+        if(market.hasCondition(Conditions.RARE_ORE_SPARSE))
         {
-            boggledTools.removeCondition(market, "rare_ore_sparse");
-            boggledTools.addCondition(market, "rare_ore_moderate");
+            boggledTools.removeCondition(market, Conditions.RARE_ORE_SPARSE);
+            boggledTools.addCondition(market, Conditions.RARE_ORE_MODERATE);
         }
-        else if(market.hasCondition("rare_ore_moderate"))
+        else if(market.hasCondition(Conditions.RARE_ORE_MODERATE))
         {
-            boggledTools.removeCondition(market, "rare_ore_moderate");
-            boggledTools.addCondition(market, "rare_ore_abundant");
+            boggledTools.removeCondition(market, Conditions.RARE_ORE_MODERATE);
+            boggledTools.addCondition(market, Conditions.RARE_ORE_ABUNDANT);
         }
-        else if(market.hasCondition("rare_ore_abundant"))
+        else if(market.hasCondition(Conditions.RARE_ORE_ABUNDANT))
         {
-            boggledTools.removeCondition(market, "rare_ore_abundant");
-            boggledTools.addCondition(market, "rare_ore_rich");
+            boggledTools.removeCondition(market, Conditions.RARE_ORE_ABUNDANT);
+            boggledTools.addCondition(market, Conditions.RARE_ORE_RICH);
         }
-        else if(market.hasCondition("rare_ore_rich"))
+        else if(market.hasCondition(Conditions.RARE_ORE_RICH))
         {
-            boggledTools.removeCondition(market, "rare_ore_rich");
-            boggledTools.addCondition(market, "rare_ore_ultrarich");
+            boggledTools.removeCondition(market, Conditions.RARE_ORE_RICH);
+            boggledTools.addCondition(market, Conditions.RARE_ORE_ULTRARICH);
         }
-        else if(market.hasCondition("rare_ore_ultrarich"))
+        else if(market.hasCondition(Conditions.RARE_ORE_ULTRARICH))
         {
             //Do Nothing
         }
         else
         {
-            boggledTools.addCondition(market, "rare_ore_sparse");
+            boggledTools.addCondition(market, Conditions.RARE_ORE_SPARSE);
         }
 
         boggledTools.surveyAll(market);
@@ -1892,46 +2163,46 @@ public class boggledTools
 
     public static void incrementVolatilesForOuyangOptimization(MarketAPI market)
     {
-        if(market.hasCondition("volatiles_trace"))
+        if(market.hasCondition(Conditions.VOLATILES_TRACE))
         {
-            boggledTools.removeCondition(market, "volatiles_trace");
-            boggledTools.addCondition(market, "volatiles_abundant");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_TRACE);
+            boggledTools.addCondition(market, Conditions.VOLATILES_ABUNDANT);
         }
-        else if(market.hasCondition("volatiles_diffuse"))
+        else if(market.hasCondition(Conditions.VOLATILES_DIFFUSE))
         {
-            boggledTools.removeCondition(market, "volatiles_diffuse");
-            boggledTools.addCondition(market, "volatiles_plentiful");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_DIFFUSE);
+            boggledTools.addCondition(market, Conditions.VOLATILES_PLENTIFUL);
         }
-        else if(market.hasCondition("volatiles_abundant"))
+        else if(market.hasCondition(Conditions.VOLATILES_ABUNDANT))
         {
-            boggledTools.removeCondition(market, "volatiles_abundant");
-            boggledTools.addCondition(market, "volatiles_plentiful");
+            boggledTools.removeCondition(market, Conditions.VOLATILES_ABUNDANT);
+            boggledTools.addCondition(market, Conditions.VOLATILES_PLENTIFUL);
         }
-        else if(market.hasCondition("volatiles_plentiful"))
+        else if(market.hasCondition(Conditions.VOLATILES_PLENTIFUL))
         {
             //Do nothing
         }
         else
         {
-            boggledTools.addCondition(market, "volatiles_diffuse");
+            boggledTools.addCondition(market, Conditions.VOLATILES_DIFFUSE);
         }
 
         SectorEntityToken closestGasGiantToken = market.getPrimaryEntity();
         if(closestGasGiantToken != null)
         {
             for (SectorEntityToken entity : closestGasGiantToken.getStarSystem().getAllEntities()) {
-                if (entity.hasTag("station") && entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(closestGasGiantToken) && (entity.getCustomEntitySpec().getDefaultName().equals("Side Station") || entity.getCustomEntitySpec().getDefaultName().equals("Siphon Station")) && !entity.getId().equals("beholder_station")) {
+                if (entity.hasTag(Tags.STATION) && entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(closestGasGiantToken) && (entity.getCustomEntitySpec().getDefaultName().equals("Side Station") || entity.getCustomEntitySpec().getDefaultName().equals("Siphon Station")) && !entity.getId().equals("beholder_station")) {
                     if (entity.getMarket() != null) {
                         market = entity.getMarket();
-                        if (market.hasCondition("volatiles_trace")) {
-                            boggledTools.removeCondition(market, "volatiles_trace");
-                            boggledTools.addCondition(market, "volatiles_abundant");
-                        } else if (market.hasCondition("volatiles_diffuse")) {
-                            boggledTools.removeCondition(market, "volatiles_diffuse");
-                            boggledTools.addCondition(market, "volatiles_plentiful");
-                        } else if (market.hasCondition("volatiles_abundant")) {
-                            boggledTools.removeCondition(market, "volatiles_abundant");
-                            boggledTools.addCondition(market, "volatiles_plentiful");
+                        if (market.hasCondition(Conditions.VOLATILES_TRACE)) {
+                            boggledTools.removeCondition(market, Conditions.VOLATILES_TRACE);
+                            boggledTools.addCondition(market, Conditions.VOLATILES_ABUNDANT);
+                        } else if (market.hasCondition(Conditions.VOLATILES_DIFFUSE)) {
+                            boggledTools.removeCondition(market, Conditions.VOLATILES_DIFFUSE);
+                            boggledTools.addCondition(market, Conditions.VOLATILES_PLENTIFUL);
+                        } else if (market.hasCondition(Conditions.VOLATILES_ABUNDANT)) {
+                            boggledTools.removeCondition(market, Conditions.VOLATILES_ABUNDANT);
+                            boggledTools.addCondition(market, Conditions.VOLATILES_PLENTIFUL);
                         }
 
                         boggledTools.surveyAll(market);
@@ -1998,7 +2269,7 @@ public class boggledTools
 
     public static void applyPlanetKiller(MarketAPI market)
     {
-        if(Misc.isStoryCritical(market) && !boggledTools.getBooleanSetting("boggledPlanetKillerAllowDestructionOfColoniesMarkedAsEssentialForQuests"))
+        if(Misc.isStoryCritical(market) && !boggledTools.getBooleanSetting(BoggledSettings.planetKillerAllowDestructionOfColoniesMarkedAsEssentialForQuests))
         {
             // Should never be reached because deployment will be disabled.
             return;
@@ -2023,9 +2294,9 @@ public class boggledTools
     public static void changePlanetTypeWithPlanetKiller(MarketAPI market)
     {
         String planetType = getPlanetType(market.getPlanetEntity());
-        if(!planetType.equals("star") && !planetType.equals("gas_giant") && !planetType.equals("volcanic") && !planetType.equals("unknown"))
+        if(!planetType.equals(starPlanetID) && !planetType.equals(gasGiantPlanetID) && !planetType.equals(volcanicPlanetID) && !planetType.equals(unknownPlanetID))
         {
-            changePlanetType(market.getPlanetEntity(), "irradiated");
+            changePlanetType(market.getPlanetEntity(), Conditions.IRRADIATED);
             market.addCondition(Conditions.IRRADIATED);
         }
     }
@@ -2035,30 +2306,30 @@ public class boggledTools
         // Modded conditions
 
         // Vanilla Conditions
-        removeCondition(market, "habitable");
-        removeCondition(market, "mild_climate");
-        removeCondition(market, "water_surface");
-        removeCondition(market, "volturnian_lobster_pens");
+        removeCondition(market, Conditions.HABITABLE);
+        removeCondition(market, Conditions.MILD_CLIMATE);
+        removeCondition(market, Conditions.WATER_SURFACE);
+        removeCondition(market, Conditions.VOLTURNIAN_LOBSTER_PENS);
 
-        removeCondition(market, "inimical_biosphere");
+        removeCondition(market, Conditions.INIMICAL_BIOSPHERE);
 
-        removeCondition(market, "farmland_poor");
-        removeCondition(market, "farmland_adequate");
-        removeCondition(market, "farmland_rich");
-        removeCondition(market, "farmland_bountiful");
+        removeCondition(market, Conditions.FARMLAND_POOR);
+        removeCondition(market, Conditions.FARMLAND_ADEQUATE);
+        removeCondition(market, Conditions.FARMLAND_RICH);
+        removeCondition(market, Conditions.FARMLAND_BOUNTIFUL);
 
         String planetType = getPlanetType(market.getPlanetEntity());
-        if(!planetType.equals("gas_giant") && !planetType.equals("unknown"))
+        if(!planetType.equals(gasGiantPlanetID) && !planetType.equals(unknownPlanetID))
         {
-            removeCondition(market, "organics_trace");
-            removeCondition(market, "organics_common");
-            removeCondition(market, "organics_abundant");
-            removeCondition(market, "organics_plentiful");
+            removeCondition(market, Conditions.ORGANICS_TRACE);
+            removeCondition(market, Conditions.ORGANICS_COMMON);
+            removeCondition(market, Conditions.ORGANICS_ABUNDANT);
+            removeCondition(market, Conditions.ORGANICS_PLENTIFUL);
 
-            removeCondition(market, "volatiles_trace");
-            removeCondition(market, "volatiles_diffuse");
-            removeCondition(market, "volatiles_abundant");
-            removeCondition(market, "volatiles_plentiful");
+            removeCondition(market, Conditions.VOLATILES_TRACE);
+            removeCondition(market, Conditions.VOLATILES_DIFFUSE);
+            removeCondition(market, Conditions.VOLATILES_ABUNDANT);
+            removeCondition(market, Conditions.VOLATILES_PLENTIFUL);
         }
     }
 
@@ -2068,12 +2339,12 @@ public class boggledTools
         for(FactionAPI faction : Global.getSector().getAllFactions())
         {
             String factionId = faction.getId();
-            if(factionId.equals("luddic_path") && market.getFactionId().equals("luddic_path"))
+            if(factionId.equals(Factions.LUDDIC_PATH) && market.getFactionId().equals(Factions.LUDDIC_PATH))
             {
                 factionsToMakeHostile.add(faction);
             }
 
-            if(!factionId.equals("player") && !factionId.equals("derelict") && !factionId.equals("luddic_path") && !factionId.equals("omega") && !factionId.equals("remnants") && !factionId.equals("sleepers"))
+            if(!factionId.equals(Factions.PLAYER) && !factionId.equals(Factions.DERELICT) && !factionId.equals(Factions.LUDDIC_PATH) && !factionId.equals(Factions.OMEGA) && !factionId.equals(Factions.REMNANTS) && !factionId.equals(Factions.SLEEPER))
             {
                 factionsToMakeHostile.add(faction);
             }
@@ -2086,7 +2357,7 @@ public class boggledTools
     {
         for(FactionAPI faction : factionsToMakeHostileDueToPlanetKillerUsage(market))
         {
-            faction.setRelationship("player", -100f);
+            faction.setRelationship(Factions.PLAYER, -100f);
         }
     }
 
@@ -2175,160 +2446,14 @@ public class boggledTools
 
         market.getPlanetEntity().changeType(newPlanetType, null);
 
-        switch (newPlanetType) {
-            case "jungle":
-                // Modded conditions
-                removeCondition(market, "US_storm");
-
-                // Vanilla Conditions
-                addCondition(market, "habitable");
-                removeCondition(market, "water_surface");
-                removeCondition(market, "volturnian_lobster_pens");
-
-                removeCondition(market, "farmland_poor");
-                addCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                removeCondition(market, "organics_trace");
-                addCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                removeCondition(market, "volatiles_trace");
-                removeCondition(market, "volatiles_diffuse");
-                removeCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
-            case "arid":
-                // Modded conditions
-
-                // Vanilla Conditions
-                addCondition(market, "habitable");
-                removeCondition(market, "water_surface");
-                removeCondition(market, "volturnian_lobster_pens");
-
-                removeCondition(market, "farmland_poor");
-                addCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                removeCondition(market, "organics_trace");
-                addCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                removeCondition(market, "volatiles_trace");
-                removeCondition(market, "volatiles_diffuse");
-                removeCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
-            case "terran":
-            case "US_auric":
-            case "US_water":
-            case "US_continent":
-                // Modded conditions
-                removeCondition(market, "US_storm");
-
-                // Vanilla Conditions
-                addCondition(market, "habitable");
-                removeCondition(market, "water_surface");
-                removeCondition(market, "volturnian_lobster_pens");
-
-                removeCondition(market, "farmland_poor");
-                addCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                addCondition(market, "organics_trace");
-                removeCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    addCondition(market, "volatiles_trace");
-                } else {
-                    removeCondition(market, "volatiles_trace");
-                }
-                removeCondition(market, "volatiles_diffuse");
-                removeCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
-            case "water":
-                // Modded conditions
-                removeCondition(market, "US_storm");
-
-                // Vanilla Conditions
-                addCondition(market, "habitable");
-                addCondition(market, "water_surface");
-
-                removeCondition(market, "farmland_poor");
-                removeCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                removeCondition(market, "organics_trace");
-                removeCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                removeCondition(market, "volatiles_trace");
-                removeCondition(market, "volatiles_diffuse");
-                removeCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
-            case "tundra":
-                // Modded conditions
-                removeCondition(market, "US_storm");
-
-                // Vanilla Conditions
-                addCondition(market, "habitable");
-                removeCondition(market, "water_surface");
-                removeCondition(market, "volturnian_lobster_pens");
-
-                removeCondition(market, "farmland_poor");
-                addCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                addCondition(market, "organics_trace");
-                removeCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    addCondition(market, "volatiles_trace");
-                } else {
-                    removeCondition(market, "volatiles_trace");
-                }
-                removeCondition(market, "volatiles_diffuse");
-                removeCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
-            case "frozen":
-                // Modded conditions
-                removeCondition(market, "US_storm");
-
-                // Vanilla Conditions
-                removeCondition(market, "habitable");
-                removeCondition(market, "water_surface");
-                removeCondition(market, "volturnian_lobster_pens");
-
-                removeCondition(market, "farmland_poor");
-                removeCondition(market, "farmland_adequate");
-                removeCondition(market, "farmland_rich");
-                removeCondition(market, "farmland_bountiful");
-
-                removeCondition(market, "organics_trace");
-                removeCondition(market, "organics_common");
-                removeCondition(market, "organics_abundant");
-                removeCondition(market, "organics_plentiful");
-
-                removeCondition(market, "volatiles_trace");
-                removeCondition(market, "volatiles_diffuse");
-                addCondition(market, "volatiles_abundant");
-                removeCondition(market, "volatiles_plentiful");
-                break;
+        Pair<ArrayList<String>, ArrayList<String>> conditionsAddedRemoved = planetTypeChangeConditions.get(newPlanetType);
+        if (conditionsAddedRemoved != null) {
+            for (String addedCondition : conditionsAddedRemoved.one) {
+                addCondition(market, addedCondition);
+            }
+            for (String removedCondition : conditionsAddedRemoved.two) {
+                removeCondition(market, removedCondition);
+            }
         }
 
         surveyAll(market);
@@ -2361,8 +2486,8 @@ public class boggledTools
             //  - Market is size 5 or larger
             //  - Market has operational Orbital Works with Pristine Nanoforge installed
 
-            int artifactCost = boggledTools.getIntSetting("boggledDomainTechCraftingArtifactCost");
-            int storyPointCost = boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost");
+            int artifactCost = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingArtifactCost);
+            int storyPointCost = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost);
             int adjustedArtifactCost = 0;
             if(project.contains("Hard"))
             {
@@ -2394,21 +2519,6 @@ public class boggledTools
         return new String[]{"You should never see this text. If you do, tell Boggled about it on the forums."};
     }
 
-    private static String[] appendLineTostringArray(String[] existingArray, String lineToAppend)
-    {
-        if(lineToAppend == null)
-        {
-            return existingArray;
-        }
-        else
-        {
-            String[] returnArray = new String[existingArray.length + 1];
-            System.arraycopy(existingArray, 0, returnArray, 0, existingArray.length);
-            returnArray[existingArray.length] = lineToAppend;
-            return returnArray;
-        }
-    }
-
     public static boolean requirementMet(MarketAPI market, String requirement)
     {
         PlanetAPI planet = null;
@@ -2428,35 +2538,35 @@ public class boggledTools
         }
         else if(requirement.equals(colonyNotAridWorld))
         {
-            return !planetType.equals("desert");
+            return !planetType.equals(desertPlanetID);
         }
         else if(requirement.equals(colonyNotJungleWorld))
         {
-            return !planetType.equals("jungle");
+            return !planetType.equals(junglePlanetID);
         }
         else if(requirement.equals(colonyNotTerranWorld))
         {
-            return !planetType.equals("terran");
+            return !planetType.equals(terranPlanetID);
         }
         else if(requirement.equals(colonyNotWaterWorld))
         {
-            return !planetType.equals("water");
+            return !planetType.equals(waterPlanetID);
         }
         else if(requirement.equals(colonyNotTundraWorld))
         {
-            return !planetType.equals("tundra");
+            return !planetType.equals(tundraPlanetID);
         }
         else if(requirement.equals(colonyNotFrozenWorld))
         {
-            return !planetType.equals("frozen");
+            return !planetType.equals(frozenPlanetID);
         }
         else if(requirement.equals(colonyBarrenOrFrozen))
         {
-            return planetType.equals("barren") || planetType.equals("frozen");
+            return planetType.equals(barrenPlanetID) || planetType.equals(frozenPlanetID);
         }
         else if(requirement.equals(colonyAtmosphericDensityNormal))
         {
-            if(market.hasCondition("no_atmosphere") || market.hasCondition("thin_atmosphere") || market.hasCondition("dense_atmosphere"))
+            if(market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE))
             {
                 return false;
             }
@@ -2467,7 +2577,7 @@ public class boggledTools
         }
         else if(requirement.equals(colonyAtmosphereNotToxicOrIrradiated))
         {
-            if(market.hasCondition("toxic_atmosphere") || market.hasCondition("irradiated"))
+            if(market.hasCondition(Conditions.TOXIC_ATMOSPHERE) || market.hasCondition(Conditions.IRRADIATED))
             {
                 return false;
             }
@@ -2478,31 +2588,31 @@ public class boggledTools
         }
         else if(requirement.equals(colonyNotColdOrVeryCold))
         {
-            return !market.hasCondition("cold") && !market.hasCondition("very_cold");
+            return !market.hasCondition(Conditions.COLD) && !market.hasCondition(Conditions.VERY_COLD);
         }
         else if(requirement.equals(colonyHotOrVeryHot))
         {
-            return market.hasCondition("hot") || market.hasCondition("very_hot");
+            return market.hasCondition(Conditions.HOT) || market.hasCondition(Conditions.VERY_HOT);
         }
         else if(requirement.equals(colonyNotVeryColdOrVeryHot))
         {
-            return !market.hasCondition("very_hot") && !market.hasCondition("very_cold");
+            return !market.hasCondition(Conditions.VERY_HOT) && !market.hasCondition(Conditions.VERY_COLD);
         }
         else if(requirement.equals(colonyNotHotOrVeryHot))
         {
-            return !market.hasCondition("hot") && !market.hasCondition("very_hot");
+            return !market.hasCondition(Conditions.HOT) && !market.hasCondition(Conditions.VERY_HOT);
         }
         else if(requirement.equals(colonyVeryCold))
         {
-            return market.hasCondition("very_cold");
+            return market.hasCondition(Conditions.VERY_COLD);
         }
         else if(requirement.equals(colonyTemperateOrHot))
         {
-            return !market.hasCondition("very_cold") && !market.hasCondition("cold") && !market.hasCondition("very_hot");
+            return !market.hasCondition(Conditions.VERY_COLD) && !market.hasCondition(Conditions.COLD) && !market.hasCondition(Conditions.VERY_HOT);
         }
         else if(requirement.equals(colonyTemperateOrCold))
         {
-            return !market.hasCondition("very_cold") && !market.hasCondition("hot") && !market.hasCondition("very_hot");
+            return !market.hasCondition(Conditions.VERY_COLD) && !market.hasCondition(Conditions.HOT) && !market.hasCondition(Conditions.VERY_HOT);
         }
         else if(requirement.equals(colonyHasStellarReflectors))
         {
@@ -2526,35 +2636,35 @@ public class boggledTools
         }
         else if(requirement.equals(colonyHabitable))
         {
-            return market.hasCondition("habitable");
+            return market.hasCondition(Conditions.HABITABLE);
         }
         else if(requirement.equals(colonyNotAlreadyHabitable))
         {
-            return !market.hasCondition("habitable");
+            return !market.hasCondition(Conditions.HABITABLE);
         }
         else if(requirement.equals(colonyExtremeWeather))
         {
-            return market.hasCondition("extreme_weather") || market.hasCondition("US_storm");
+            return market.hasCondition(Conditions.EXTREME_WEATHER) || market.hasCondition("US_storm");
         }
         else if(requirement.equals(colonyNormalClimate))
         {
-            return !market.hasCondition("mild_climate") && !market.hasCondition("extreme_weather") && !market.hasCondition("US_storm");
+            return !market.hasCondition(Conditions.MILD_CLIMATE) && !market.hasCondition(Conditions.EXTREME_WEATHER) && !market.hasCondition("US_storm");
         }
         else if(requirement.equals(colonyAtmosphereToxic))
         {
-            return market.hasCondition("toxic_atmosphere");
+            return market.hasCondition(Conditions.TOXIC_ATMOSPHERE);
         }
         else if(requirement.equals(colonyIrradiated))
         {
-            return market.hasCondition("irradiated");
+            return market.hasCondition(Conditions.IRRADIATED);
         }
         else if(requirement.equals(colonyHasAtmosphere))
         {
-            return !market.hasCondition("no_atmosphere");
+            return !market.hasCondition(Conditions.NO_ATMOSPHERE);
         }
         else if(requirement.equals(colonyAtmosphereSuboptimalDensity))
         {
-            return market.hasCondition("no_atmosphere") || market.hasCondition("thin_atmosphere") || market.hasCondition("dense_atmosphere");
+            return market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE);
         }
         else if(requirement.equals(worldTypeSupportsFarmlandImprovement))
         {
@@ -2570,7 +2680,7 @@ public class boggledTools
         }
         else if(requirement.equals(worldTypeAllowsTerraforming))
         {
-            if(planetType.equals("star") || planetType.equals("gas_giant") || planetType.equals("volcanic") || planetType.equals("unknown"))
+            if(planetType.equals(starPlanetID) || planetType.equals(gasGiantPlanetID) || planetType.equals(volcanicPlanetID) || planetType.equals(unknownPlanetID))
             {
                 return false;
             }
@@ -2581,7 +2691,7 @@ public class boggledTools
         }
         else if(requirement.equals(worldTypeAllowsMildClimate) || requirement.equals(worldTypeAllowsHumanHabitability))
         {
-            if(planetType.equals("jungle") || planetType.equals("desert") || planetType.equals("terran") || planetType.equals("water") || planetType.equals("tundra"))
+            if(planetType.equals(junglePlanetID) || planetType.equals(desertPlanetID) || planetType.equals(terranPlanetID) || planetType.equals(waterPlanetID) || planetType.equals(tundraPlanetID))
             {
                 return true;
             }
@@ -2606,7 +2716,7 @@ public class boggledTools
             if(market.hasIndustry(Industries.ORBITALWORKS) && market.getIndustry(Industries.ORBITALWORKS).isFunctional())
             {
                 for (SpecialItemData data : market.getIndustry(Industries.ORBITALWORKS).getVisibleInstalledItems()) {
-                    if (data.getId().equals("pristine_nanoforge") || data.getId().equals("uaf_dimen_nanoforge")) {
+                    if (data.getId().equals(Items.PRISTINE_NANOFORGE) || data.getId().equals("uaf_dimen_nanoforge")) {
                         return true;
                     }
                 }
@@ -2617,12 +2727,12 @@ public class boggledTools
         {
             String[] words = requirement.split(" ");
             CargoAPI playerCargo = Global.getSector().getPlayerFleet().getCargo();
-            return playerCargo.getCommodityQuantity("domain_artifacts") >= Integer.parseInt(words[5]);
+            return playerCargo.getCommodityQuantity(BoggledCommodities.domainArtifacts) >= Integer.parseInt(words[5]);
         }
-        else if(requirement.equals(boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost") + " story points available to spend"))
+        else if(requirement.equals(boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost) + " story points available to spend"))
         {
             MutableCharacterStatsAPI charStats = Global.getSector().getPlayerStats();
-            return charStats.getStoryPoints() >= boggledTools.getIntSetting("boggledDomainTechCraftingStoryPointCost");
+            return charStats.getStoryPoints() >= boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost);
         }
 //        else if(requirement.equals(aotd_TypeChangeResearchRequirement))
 //        {
@@ -2661,7 +2771,7 @@ public class boggledTools
         Color good = Misc.getPositiveHighlightColor();
         Color bad = Misc.getNegativeHighlightColor();
 
-        if(project != null && !project.equals("None"))
+        if(project != null && !project.equals(noneProjectID))
         {
             // Print requirements, and if not met, print terraforming is stalled
             text.addPara("Project Requirements:");
@@ -2811,11 +2921,11 @@ public class boggledTools
 
         PlanetAPI planet = market.getPlanetEntity();
         String planetType = getPlanetType(planet);
-        if(planetType.equals("water") || planetType.equals("frozen") || planetType.equals("US_water") || planetType.equals("US_waterB") || hasIsmaraSling(market) || market.hasCondition("water_surface"))
+        if(planetType.equals(waterPlanetID) || planetType.equals(frozenPlanetID) || planetType.equals("US_water") || planetType.equals("US_waterB") || hasIsmaraSling(market) || market.hasCondition(Conditions.WATER_SURFACE))
         {
             return 2;
         }
-        else if(planetType.equals("desert") || planetType.equals("terran") || planetType.equals("tundra") || planetType.equals("jungle") || (planetType.contains("US_") && market.hasCondition("habitable") && !market.hasCondition("no_atmosphere")))
+        else if(planetType.equals(desertPlanetID) || planetType.equals(terranPlanetID) || planetType.equals(tundraPlanetID) || planetType.equals(junglePlanetID) || (planetType.contains("US_") && market.hasCondition(Conditions.HABITABLE) && !market.hasCondition(Conditions.NO_ATMOSPHERE)))
         {
             return 1;
         }
@@ -2827,33 +2937,19 @@ public class boggledTools
 
     public static boolean marketHasAtmosphereProcessor(MarketAPI market)
     {
-        if(market.getIndustry("BOGGLED_ATMOSPHERE_PROCESSOR") != null && market.getIndustry("BOGGLED_ATMOSPHERE_PROCESSOR").isFunctional() && market.hasIndustry("BOGGLED_ATMOSPHERE_PROCESSOR"))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return market.getIndustry(BoggledIndustries.atmosphereProcessorIndustryID) != null && market.getIndustry(BoggledIndustries.atmosphereProcessorIndustryID).isFunctional() && market.hasIndustry(BoggledIndustries.atmosphereProcessorIndustryID);
     }
 
     public static boolean marketHasGenelab(MarketAPI market)
     {
-        if(market.getIndustry("BOGGLED_GENELAB") != null && market.getIndustry("BOGGLED_GENELAB").isFunctional() && market.hasIndustry("BOGGLED_GENELAB"))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return market.getIndustry(BoggledIndustries.genelabIndustryID) != null && market.getIndustry(BoggledIndustries.genelabIndustryID).isFunctional() && market.hasIndustry(BoggledIndustries.genelabIndustryID);
     }
 
     public static boolean marketHasStellarReflectorArray(MarketAPI market)
     {
         // Should be functionally the same as the commented out code, unless the player disables autoplacement in the settings file.
         // Then this will allow terraforming on planets that start with reflectors without having to build the structure on them.
-        return market.hasCondition("solar_array");
+        return market.hasCondition(Conditions.SOLAR_ARRAY);
 
         /*
         if(market.getIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY") != null && market.getIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY").isFunctional() && market.hasIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY"))
@@ -2869,7 +2965,7 @@ public class boggledTools
 
     public static boolean marketHasAtmoProblem(MarketAPI market)
     {
-        if(!market.hasCondition("mild_climate") || !market.hasCondition("habitable") || market.hasCondition("no_atmosphere") || market.hasCondition("thin_atmosphere") || market.hasCondition("dense_atmosphere") || market.hasCondition("toxic_atmosphere") || market.hasCondition("US_storm"))
+        if(!market.hasCondition(Conditions.MILD_CLIMATE) || !market.hasCondition(Conditions.HABITABLE) || market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE) || market.hasCondition(Conditions.TOXIC_ATMOSPHERE) || market.hasCondition("US_storm"))
         {
             return true;
         }
@@ -2881,14 +2977,7 @@ public class boggledTools
 
     public static boolean marketIsIrradiated(MarketAPI market)
     {
-        if(market.hasCondition("irradiated"))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+        return market.hasCondition(Conditions.IRRADIATED);
     }
 
     public static int waterLevelNeededForProject(String project)
@@ -2935,9 +3024,9 @@ public class boggledTools
 
     public static String getTooltipProjectName(String currentProject)
     {
-        if(currentProject == null || currentProject.equals("None"))
+        if(currentProject == null || currentProject.equals(noneProjectID))
         {
-            return "None";
+            return noneProjectID;
         }
 
         String tooltip = projectTooltip.get(currentProject);
@@ -2969,7 +3058,7 @@ public class boggledTools
 
         market.addCondition(Conditions.POPULATION_3);
 
-        if(boggledTools.getBooleanSetting("boggledMiningStationLinkToResourceBelts"))
+        if(boggledTools.getBooleanSetting(BoggledSettings.miningStationLinkToResourceBelts))
         {
             int numAsteroidBeltsInSystem = boggledTools.getNumAsteroidTerrainsInSystem(stationEntity);
             String resourceLevel = boggledTools.getMiningStationResourceString(numAsteroidBeltsInSystem);
@@ -2979,7 +3068,7 @@ public class boggledTools
         else
         {
             String resourceLevel = "moderate";
-            int staticAmountPerSettings = boggledTools.getIntSetting("boggledMiningStationStaticAmount");
+            int staticAmountPerSettings = boggledTools.getIntSetting(BoggledSettings.miningStationStaticAmount);
             switch(staticAmountPerSettings)
             {
                 case 1:
@@ -3002,16 +3091,16 @@ public class boggledTools
             market.addCondition("rare_ore_" + resourceLevel);
         }
 
-        market.addCondition("sprite_controller");
-        market.addCondition("cramped_quarters");
+        market.addCondition(spriteControllerConditionID);
+        market.addCondition(crampedQuartersConditionID);
 
         //Adds the no atmosphere condition, then suppresses it so it won't increase hazard
         //market_conditions.csv overwrites the vanilla no_atmosphere condition
         //the only change made is to hide the icon on markets where primary entity has station tag
         //This is done so refining and fuel production can slot the special items
         //Hopefully Alex will fix the no_atmosphere detection in the future so this hack can be removed
-        market.addCondition("no_atmosphere");
-        market.suppressCondition("no_atmosphere");
+        market.addCondition(Conditions.NO_ATMOSPHERE);
+        market.suppressCondition(Conditions.NO_ATMOSPHERE);
 
         market.addIndustry(Industries.POPULATION);
         market.getConstructionQueue().addToEnd(Industries.SPACEPORT, 0);
@@ -3027,15 +3116,15 @@ public class boggledTools
         Global.getSector().getCampaignUI().showInteractionDialog(stationEntity);
         //Global.getSector().getCampaignUI().getCurrentInteractionDialog().dismiss();
 
-        market.addSubmarket("storage");
-        StoragePlugin storage = (StoragePlugin)market.getSubmarket("storage").getPlugin();
+        market.addSubmarket(Submarkets.SUBMARKET_STORAGE);
+        StoragePlugin storage = (StoragePlugin)market.getSubmarket(Submarkets.SUBMARKET_STORAGE).getPlugin();
         storage.setPlayerPaidToUnlock(true);
-        market.addSubmarket("local_resources");
+        market.addSubmarket(Submarkets.LOCAL_RESOURCES);
 
         boggledTools.surveyAll(market);
         boggledTools.refreshSupplyAndDemand(market);
 
-        Global.getSoundPlayer().playUISound("ui_boggled_station_constructed", 1.0F, 1.0F);
+        Global.getSoundPlayer().playUISound(BoggledSounds.stationConstructed, 1.0F, 1.0F);
 
         return market;
     }
@@ -3058,7 +3147,7 @@ public class boggledTools
 
         market.addCondition(Conditions.POPULATION_3);
 
-        if(boggledTools.getBooleanSetting("boggledSiphonStationLinkToGasGiant"))
+        if(boggledTools.getBooleanSetting(BoggledSettings.siphonStationLinkToGasGiant))
         {
             if(hostGasGiant.getMarket().hasCondition(Conditions.VOLATILES_TRACE))
             {
@@ -3084,7 +3173,7 @@ public class boggledTools
         else
         {
             String resourceLevel = "diffuse";
-            int staticAmountPerSettings = boggledTools.getIntSetting("boggledSiphonStationStaticAmount");
+            int staticAmountPerSettings = boggledTools.getIntSetting(BoggledSettings.siphonStationStaticAmount);
             switch(staticAmountPerSettings)
             {
                 case 1:
@@ -3103,16 +3192,16 @@ public class boggledTools
             market.addCondition("volatiles_" + resourceLevel);
         }
 
-        market.addCondition("sprite_controller");
-        market.addCondition("cramped_quarters");
+        market.addCondition(spriteControllerConditionID);
+        market.addCondition(crampedQuartersConditionID);
 
         //Adds the no atmosphere condition, then suppresses it so it won't increase hazard
         //market_conditions.csv overwrites the vanilla no_atmosphere condition
         //the only change made is to hide the icon on markets where primary entity has station tag
         //This is done so refining and fuel production can slot the special items
         //Hopefully Alex will fix the no_atmosphere detection in the future so this hack can be removed
-        market.addCondition("no_atmosphere");
-        market.suppressCondition("no_atmosphere");
+        market.addCondition(Conditions.NO_ATMOSPHERE);
+        market.suppressCondition(Conditions.NO_ATMOSPHERE);
 
         market.addIndustry(Industries.POPULATION);
         market.getConstructionQueue().addToEnd(Industries.SPACEPORT, 0);
@@ -3126,15 +3215,15 @@ public class boggledTools
         Global.getSector().getCampaignUI().showInteractionDialog(stationEntity);
         //Global.getSector().getCampaignUI().getCurrentInteractionDialog().dismiss();
 
-        market.addSubmarket("storage");
-        StoragePlugin storage = (StoragePlugin)market.getSubmarket("storage").getPlugin();
+        market.addSubmarket(Submarkets.SUBMARKET_STORAGE);
+        StoragePlugin storage = (StoragePlugin)market.getSubmarket(Submarkets.SUBMARKET_STORAGE).getPlugin();
         storage.setPlayerPaidToUnlock(true);
-        market.addSubmarket("local_resources");
+        market.addSubmarket(Submarkets.LOCAL_RESOURCES);
 
         boggledTools.surveyAll(market);
         boggledTools.refreshSupplyAndDemand(market);
 
-        Global.getSoundPlayer().playUISound("ui_boggled_station_constructed", 1.0F, 1.0F);
+        Global.getSoundPlayer().playUISound(BoggledSounds.stationConstructed, 1.0F, 1.0F);
         return market;
     }
 
@@ -3154,16 +3243,16 @@ public class boggledTools
 
         market.addCondition(Conditions.POPULATION_3);
 
-        market.addCondition("sprite_controller");
-        market.addCondition("cramped_quarters");
+        market.addCondition(spriteControllerConditionID);
+        market.addCondition(crampedQuartersConditionID);
 
         //Adds the no atmosphere condition, then suppresses it so it won't increase hazard
         //market_conditions.csv overwrites the vanilla no_atmosphere condition
         //the only change made is to hide the icon on markets where primary entity has station tag
         //This is done so refining and fuel production can slot the special items
         //Hopefully Alex will fix the no_atmosphere detection in the future so this hack can be removed
-        market.addCondition("no_atmosphere");
-        market.suppressCondition("no_atmosphere");
+        market.addCondition(Conditions.NO_ATMOSPHERE);
+        market.suppressCondition(Conditions.NO_ATMOSPHERE);
 
         market.addIndustry(Industries.POPULATION);
         market.getConstructionQueue().addToEnd(Industries.SPACEPORT, 0);
@@ -3174,20 +3263,20 @@ public class boggledTools
 
         Global.getSector().getCampaignUI().showInteractionDialog(stationEntity);
 
-        market.addSubmarket("storage");
-        StoragePlugin storage = (StoragePlugin)market.getSubmarket("storage").getPlugin();
+        market.addSubmarket(Submarkets.SUBMARKET_STORAGE);
+        StoragePlugin storage = (StoragePlugin)market.getSubmarket(Submarkets.SUBMARKET_STORAGE).getPlugin();
         storage.setPlayerPaidToUnlock(true);
-        market.addSubmarket("local_resources");
+        market.addSubmarket(Submarkets.LOCAL_RESOURCES);
 
-        Global.getSoundPlayer().playUISound("ui_boggled_station_constructed", 1.0F, 1.0F);
+        Global.getSoundPlayer().playUISound(BoggledSounds.stationConstructed, 1.0F, 1.0F);
         return market;
     }
 
     public static int getLastDayCheckedForConstruction(SectorEntityToken stationEntity)
     {
         for (String tag : stationEntity.getTags()) {
-            if (tag.contains("boggled_construction_progress_lastDayChecked_")) {
-                return Integer.parseInt(tag.replaceAll("boggled_construction_progress_lastDayChecked_", ""));
+            if (tag.contains(BoggledTags.constructionProgressLastDayChecked)) {
+                return Integer.parseInt(tag.replaceAll(BoggledTags.constructionProgressLastDayChecked, ""));
             }
         }
 
@@ -3198,7 +3287,7 @@ public class boggledTools
     {
         String tagToDelete = null;
         for (String tag : stationEntity.getTags()) {
-            if (tag.contains("boggled_construction_progress_lastDayChecked_")) {
+            if (tag.contains(BoggledTags.constructionProgressLastDayChecked)) {
                 tagToDelete = tag;
                 break;
             }
@@ -3215,7 +3304,7 @@ public class boggledTools
     {
         String tagToDelete = null;
         for (String tag : market.getTags()) {
-            if (tag.contains("boggledTerraformingController")) {
+            if (tag.contains(BoggledTags.terraformingController)) {
                 tagToDelete = tag;
                 break;
             }
@@ -3231,8 +3320,8 @@ public class boggledTools
     public static int getConstructionProgressDays(SectorEntityToken stationEntity)
     {
         for (String tag : stationEntity.getTags()) {
-            if (tag.contains("boggled_construction_progress_days_")) {
-                return Integer.parseInt(tag.replaceAll("boggled_construction_progress_days_", ""));
+            if (tag.contains(BoggledTags.constructionProgressDays)) {
+                return Integer.parseInt(tag.replaceAll(BoggledTags.constructionProgressDays, ""));
             }
         }
 
@@ -3243,7 +3332,7 @@ public class boggledTools
     {
         String tagToDelete = null;
         for (String tag : stationEntity.getTags()) {
-            if (tag.contains("boggled_construction_progress_days_")) {
+            if (tag.contains(BoggledTags.constructionProgressDays)) {
                 tagToDelete = tag;
                 break;
             }
@@ -3271,47 +3360,36 @@ public class boggledTools
             strDays = "0" + strDays;
         }
 
-        stationEntity.addTag("boggled_construction_progress_days_" + strDays);
+        stationEntity.addTag(BoggledTags.constructionProgressDays + strDays);
     }
 
     public static int[] getQuantitiesForStableLocationConstruction(String type)
     {
-        if(boggledTools.getBooleanSetting("boggledDomainArchaeologyEnabled"))
-        {
-            if(type.equals("inactive_gate"))
-            {
-                return new int[]{
-                        boggledTools.getIntSetting("boggledStableLocationGateCostHeavyMachinery"),
-                        boggledTools.getIntSetting("boggledStableLocationGateCostMetals"),
-                        boggledTools.getIntSetting("boggledStableLocationGateCostTransplutonics"),
-                        boggledTools.getIntSetting("boggledStableLocationGateCostDomainEraArtifacts")};
+        ArrayList<Integer> ret = new ArrayList<>();
+
+        if (type.equals(Entities.INACTIVE_GATE)) {
+            ret.addAll(asList(
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationGateCostHeavyMachinery),
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationGateCostMetals),
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationGateCostTransplutonics)
+            ));
+            if (boggledTools.getBooleanSetting(BoggledSettings.domainArchaeologyEnabled)) {
+                ret.add(boggledTools.getIntSetting(BoggledSettings.stableLocationGateCostDomainEraArtifacts));
             }
-            else
-            {
-                return new int[]{
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostHeavyMachinery"),
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostMetals"),
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostTransplutonics"),
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostDomainEraArtifacts")};
-            }
-        }
-        else
-        {
-            if(type.equals("inactive_gate"))
-            {
-                return new int[]{
-                        boggledTools.getIntSetting("boggledStableLocationGateCostHeavyMachinery"),
-                        boggledTools.getIntSetting("boggledStableLocationGateCostMetals"),
-                        boggledTools.getIntSetting("boggledStableLocationGateCostTransplutonics")};
-            }
-            else
-            {
-                return new int[]{
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostHeavyMachinery"),
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostMetals"),
-                        boggledTools.getIntSetting("boggledStableLocationDomainTechStructureCostTransplutonics")};
+        } else {
+            ret.addAll(asList(
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationDomainTechStructureCostHeavyMachinery),
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationDomainTechStructureCostMetals),
+                    boggledTools.getIntSetting(BoggledSettings.stableLocationDomainTechStructureCostTransplutonics)
+            ));
+            if (boggledTools.getBooleanSetting(BoggledSettings.domainArchaeologyEnabled)) {
+                ret.add(boggledTools.getIntSetting(BoggledSettings.stableLocationDomainTechStructureCostDomainEraArtifacts));
             }
         }
+        int[] ret2 = new int[ret.size()];
+        Iterator<Integer> it = ret.iterator();
+        for (int i = 0; i < ret.size(); i++) ret2[i] = it.next();
+        return ret2;
     }
 
     public static SectorEntityToken getPlanetTokenForQuest(String systemID, String entityID)
@@ -3344,9 +3422,9 @@ public class boggledTools
 
     public static int getIntSetting(String key)
     {
-        if(Global.getSettings().getModManager().isModEnabled("lunalib"))
+        if(Global.getSettings().getModManager().isModEnabled(BoggledMods.lunalibModID))
         {
-            return LunaSettings.getInt("Terraforming & Station Construction", key);
+            return LunaSettings.getInt(BoggledMods.tascModID, key);
         }
         else
         {
@@ -3356,9 +3434,9 @@ public class boggledTools
 
     public static boolean getBooleanSetting(String key)
     {
-        if(Global.getSettings().getModManager().isModEnabled("lunalib"))
+        if(Global.getSettings().getModManager().isModEnabled(BoggledMods.lunalibModID))
         {
-            return LunaSettings.getBoolean("Terraforming & Station Construction", key);
+            return LunaSettings.getBoolean(BoggledMods.tascModID, key);
         }
         else
         {

--- a/src/data/campaign/econ/boggledTools.java
+++ b/src/data/campaign/econ/boggledTools.java
@@ -9,7 +9,6 @@ import com.fs.starfarer.api.campaign.econ.MarketAPI;
 import com.fs.starfarer.api.campaign.econ.MarketConditionAPI;
 import com.fs.starfarer.api.campaign.listeners.ListenerUtil;
 import com.fs.starfarer.api.campaign.rules.MemoryAPI;
-import com.fs.starfarer.api.characters.MutableCharacterStatsAPI;
 import com.fs.starfarer.api.impl.campaign.MilitaryResponseScript;
 import com.fs.starfarer.api.impl.campaign.ids.*;
 import com.fs.starfarer.api.impl.campaign.intel.BaseIntelPlugin;
@@ -132,9 +131,15 @@ public class boggledTools
         public static final String ismaraSlingIndustryID = "BOGGLED_ISMARA_SLING";
     }
 
+    public static class BoggledResources {
+        public static final String farmlandResourceID = "farmlandResource";
+        public static final String organicsResourceID = "organicsResource";
+        public static final String volatilesResourceID = "volatilesResource";
+    }
+
     private static final String starPlanetID = "star";
 
-    private static final String aridPlanetID = "arid";
+//    private static final String aridPlanetID = "arid";
     private static final String barrenPlanetID = "barren";
     private static final String desertPlanetID = "desert";
     private static final String frozenPlanetID = "frozen";
@@ -152,55 +157,66 @@ public class boggledTools
     private static final String spriteControllerConditionID = "sprite_controller";
     private static final String crampedQuartersConditionID = "cramped_quarters";
 
+    private static class BoggledProjectRequirements {
+        public static final String colonyNotJungleWorld = "Colony is not already a jungle world";
+        public static final String colonyNotAridWorld = "Colony is not already an arid world";
+        public static final String colonyNotTerranWorld = "Colony is not already a Terran world";
+        public static final String colonyNotWaterWorld = "Colony is not already a water world";
+        public static final String colonyNotTundraWorld = "Colony is not already a tundra world";
+        public static final String colonyNotFrozenWorld = "Colony is not already a frozen world";
+
+        public static final String colonyBarrenOrFrozen = "Colony is barren or frozen";
+        public static final String colonyAtmosphericDensityNormal = "Colony has normal atmospheric density";
+        public static final String colonyAtmosphereNotToxicOrIrradiated = "Colony atmosphere is not toxic or irradiated";
+        public static final String colonyNotColdOrVeryCold = "Colony is not cold or very cold";
+        public static final String colonyHotOrVeryHot = "Colony is hot or very hot";
+        public static final String colonyNotVeryColdOrVeryHot = "Colony is not very cold or very hot";
+        public static final String colonyNotHotOrVeryHot = "Colony is not hot or very hot";
+        public static final String colonyVeryCold = "Colony is very cold";
+        public static final String colonyTemperateOrHot = "Colony is temperate or hot";
+        public static final String colonyTemperateOrCold = "Colony is temperate or cold";
+
+        public static final String colonyHasStellarReflectors = "Colony has stellar reflectors";
+        public static final String colonyHasAtmosphereProcessor = "Colony has atmosphere processor";
+        public static final String colonyHasGenelab = "Colony has genelab";
+
+        public static final String colonyHasModerateWaterPresent = "Colony has a moderate amount of water present";
+        public static final String colonyHasLargeWaterPresent = "Colony has a large amount of water present";
+
+        public static final String colonyHabitable = "Colony is habitable";
+        public static final String colonyNotAlreadyHabitable = "Colony is not already habitable";
+
+        public static final String colonyExtremeWeather = "Colony has extreme weather";
+        public static final String colonyNormalClimate = "Colony has normal climate";
+
+        public static final String colonyAtmosphereToxic = "Colony atmosphere is toxic";
+        public static final String colonyIrradiated = "Colony is irradiated";
+
+        public static final String colonyHasAtmosphere = "Colony has atmosphere";
+        public static final String colonyAtmosphereSuboptimalDensity = "Colony atmosphere has suboptimal density";
+
+        public static final String worldTypeSupportsFarmlandImprovement = "World type supports further farmland improvement";
+        public static final String worldTypeSupportsOrganicsImprovement = "World type supports further organics improvement";
+        public static final String worldTypeSupportsVolatilesImprovement = "World type supports further volatiles improvement";
+
+        public static final String worldTypeAllowsTerraforming = "World type allows for terraforming";
+        public static final String worldTypeAllowsMildClimate = "World type allows for mild climate";
+        public static final String worldTypeAllowsHumanHabitability = "World type allows for human habitability";
+
+        public static final String colonyHasAtLeast100kInhabitants = "Colony has at least 100,000 inhabitants";
+
+        public static final String colonyHasOrbitalWorksWPristineNanoforge = "Colony has orbital works with a pristine nanoforge";
+
+        private static final String aotd_TypeChangeResearchRequirement = "Researched: Terraforming Templates";
+        private static final String aotd_ConditionImprovementResearchRequirement = "Researched : Atmosphere Manipulation";
+        private static final String aotd_ResourceImprovementResearchRequirement = "Researched : Advanced Terraforming Templates";
+
+        private static final String aotd_TypeChangeResearchRequirementID = "tasc_terraforming_templates";
+        private static final String aotd_ConditionImprovementResearchRequirementID = "tasc_atmosphere_manipulation";
+        private static final String aotd_ResourceImprovementResearchRequirementID = "tasc_advacned_terraforming";
+    }
     // A mistyped string compiles fine and leads to plenty of debugging. A mistyped constant gives an error.
-    private static final String colonyNotJungleWorld = "Colony is not already a jungle world";
-    private static final String colonyNotAridWorld = "Colony is not already an arid world";
-    private static final String colonyNotTerranWorld = "Colony is not already a Terran world";
-    private static final String colonyNotWaterWorld = "Colony is not already a water world";
-    private static final String colonyNotTundraWorld = "Colony is not already a tundra world";
-    private static final String colonyNotFrozenWorld = "Colony is not already a frozen world";
 
-    private static final String colonyBarrenOrFrozen = "Colony is barren or frozen";
-    private static final String colonyAtmosphericDensityNormal = "Colony has normal atmospheric density";
-    private static final String colonyAtmosphereNotToxicOrIrradiated = "Colony atmosphere is not toxic or irradiated";
-    private static final String colonyNotColdOrVeryCold = "Colony is not cold or very cold";
-    private static final String colonyHotOrVeryHot = "Colony is hot or very hot";
-    private static final String colonyNotVeryColdOrVeryHot = "Colony is not very cold or very hot";
-    private static final String colonyNotHotOrVeryHot = "Colony is not hot or very hot";
-    private static final String colonyVeryCold = "Colony is very cold";
-    private static final String colonyTemperateOrHot = "Colony is temperate or hot";
-    private static final String colonyTemperateOrCold = "Colony is temperate or cold";
-
-    private static final String colonyHasStellarReflectors = "Colony has stellar reflectors";
-    private static final String colonyHasAtmosphereProcessor = "Colony has atmosphere processor";
-    private static final String colonyHasGenelab = "Colony has genelab";
-
-    private static final String colonyHasModerateWaterPresent = "Colony has a moderate amount of water present";
-    private static final String colonyHasLargeWaterPresent = "Colony has a large amount of water present";
-
-    private static final String colonyHabitable = "Colony is habitable";
-    private static final String colonyNotAlreadyHabitable = "Colony is not already habitable";
-
-    private static final String colonyExtremeWeather = "Colony has extreme weather";
-    private static final String colonyNormalClimate = "Colony has normal climate";
-
-    private static final String colonyAtmosphereToxic = "Colony atmosphere is toxic";
-    private static final String colonyIrradiated = "Colony is irradiated";
-
-    private static final String colonyHasAtmosphere = "Colony has atmosphere";
-    private static final String colonyAtmosphereSuboptimalDensity = "Colony atmosphere has suboptimal density";
-
-    private static final String worldTypeSupportsFarmlandImprovement = "World type supports further farmland improvement";
-    private static final String worldTypeSupportsOrganicsImprovement = "World type supports further organics improvement";
-    private static final String worldTypeSupportsVolatilesImprovement = "World type supports further volatiles improvement";
-
-    private static final String worldTypeAllowsTerraforming = "World type allows for terraforming";
-    private static final String worldTypeAllowsMildClimate = "World type allows for mild climate";
-    private static final String worldTypeAllowsHumanHabitability = "World type allows for human habitability";
-
-    private static final String colonyHasAtLeast100kInhabitants = "Colony has at least 100,000 inhabitants";
-
-    private static final String colonyHasOrbitalWorksWPristineNanoforge = "Colony has orbital works with a pristine nanoforge";
 
     public static final String noneProjectID = "None";
 
@@ -221,300 +237,58 @@ public class boggledTools
     public static final String atmosphereDensityConditionImprovementProjectID = "atmosphereDensityConditionImprovement";
     public static final String toxicAtmosphereConditionImprovementProjectID = "toxicAtmosphereConditionImprovement";
     public static final String irradiatedConditionImprovementProjectID = "irradiatedConditionImprovement";
-    public static final String radiationConditionImprovementProjectID = "irradiatedConditionImprovement";
     public static final String removeAtmosphereConditionImprovementProjectID = "removeAtmosphereConditionImprovement";
 
-    private static final String aotd_TypeChangeResearchRequirement = "Researched: Terraforming Templates";
-    private static final String aotd_ConditionImprovementResearchRequirement = "Researched : Atmosphere Manipulation";
-    private static final String aotd_ResourceImprovementResearchRequirement = "Researched : Advanced Terraforming Templates";
+    public static final String jungleTypeChangeProjectTooltip =  "Jungle type change";
+    public static final String aridTypeChangeProjectTooltip = "Arid type change";
+    public static final String terranTypeChangeProjectTooltip = "Terran type change";
+    public static final String waterTypeChangeProjectTooltip = "Water type change";
+    public static final String tundraTypeChangeProjectTooltip = "Tundra type change";
+    public static final String frozenTypeChangeProjectTooltip = "Frozen type change";
 
-    private static final String aotd_TypeChangeResearchRequirementID = "tasc_terraforming_templates";
-    private static final String aotd_ConditionImprovementResearchRequirementID = "tasc_atmosphere_manipulation";
-    private static final String aotd_ResourceImprovementResearchRequirementID = "tasc_advacned_terraforming";
+    public static final String farmlandResourceImprovementProjectTooltip = "Farmland resource improvement";
+    public static final String organicsResourceImprovementProjectTooltip = "Organics resource improvement";
+    public static final String volatilesResourceImprovementProjectTooltip = "Volatiles resource improvement";
 
-    private static HashMap<String, String[]> initialiseProjectRequirements() {
-        HashMap<String, String[]> ret = new HashMap<>();
+    public static final String extremeWeatherConditionImprovementProjectTooltip = "Stabilize weather patterns";
+    public static final String mildClimateConditionImprovementProjectTooltip = "Make climate mild";
+    public static final String habitableConditionImprovementProjectTooltip = "Make atmosphere habitable";
+    public static final String atmosphereDensityConditionImprovementProjectTooltip = "Normalize atmospheric density";
+    public static final String toxicAtmosphereConditionImprovementProjectTooltip = "Reduce atmosphere toxicity";
+    public static final String irradiatedConditionImprovementProjectTooltip = "Remove atmospheric radiation";
+    public static final String removeAtmosphereConditionImprovementProjectTooltip = "Remove the atmosphere";
 
-        boolean aotd_Enabled = Global.getSettings().getModManager().isModEnabled("aotd_vok");
+    public static final String craftCorruptedNanoforgeProjectID = "craftCorruptedNanoforge";
+    public static final String craftPristineNanoforgeProjectID = "craftPristineNanoforge";
+    public static final String craftSynchrotronProjectID = "craftSynchrotron";
+    public static final String craftHypershuntTapProjectID = "craftHypershuntTap";
+    public static final String craftCryoarithmeticEngineProjectID = "craftCryoarithmeticEngine";
+    public static final String craftPlanetKillerDeviceProjectID = "craftPlanetKillerDevice";
+    public static final String craftFusionLampProjectID = "craftFusionLamp";
+    public static final String craftFullereneSpoolProjectID = "craftFullereneSpool";
+    public static final String craftPlasmaDynamoProjectID = "craftPlasmaDynamo";
+    public static final String craftAutonomousMantleBoreProjectID = "craftAutonomousMantleBore";
+    public static final String craftSoilNanitesProjectID = "craftSoilNanites";
+    public static final String craftCatalyticCoreProjectID = "craftCatalyticCore";
+    public static final String craftCombatDroneReplicatorProjectID = "craftCombatDroneReplicator";
+    public static final String craftBiofactoryEmbryoProjectID = "crafyBiofactoryEmbryo";
+    public static final String craftDealmakerHolosuiteProjectID = "craftDealmakerHolosuite";
 
-        // Requires:
-        //  - Not already arid
-        //  - Normal atmosphere
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Colony is temperate or hot
-        //  - Stellar Reflectors
-        //  - Water Level of 1
-        ArrayList<String> aridTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotAridWorld,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyTemperateOrHot,
-                colonyHasStellarReflectors,
-                colonyHasModerateWaterPresent
-        ));
-
-        // Requires:
-        //  - Not already jungle
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Colony is temperate or hot
-        //  - Stellar Reflectors
-        //  - Water Level of 1
-        ArrayList<String> jungleTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotJungleWorld,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyTemperateOrHot,
-                colonyHasStellarReflectors,
-                colonyHasModerateWaterPresent
-        ));
-
-        // Requires:
-        //  - Not already Terran
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Not very cold or very hot temperature
-        //  - Stellar Reflectors
-        //  - Water Level of 1
-        ArrayList<String> terranTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotTerranWorld,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyNotVeryColdOrVeryHot,
-                colonyHasStellarReflectors,
-                colonyHasModerateWaterPresent
-        ));
-
-        // Requires:
-        //  - Not already water
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Not very cold or very hot temperature
-        //  - Stellar Reflectors
-        //  - Water Level of 2
-        ArrayList<String> waterTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotWaterWorld,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyNotVeryColdOrVeryHot,
-                colonyHasStellarReflectors,
-                colonyHasLargeWaterPresent
-        ));
-
-        // Requires:
-        //  - Not already tundra
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Colony is temperate or cold
-        //  - Stellar Reflectors
-        //  - Water Level of 1
-        ArrayList<String> tundraTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotTundraWorld,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyTemperateOrCold,
-                colonyHasStellarReflectors,
-                colonyHasModerateWaterPresent
-        ));
-
-        // Requires:
-        //  - Not already frozen
-        //  - Normal atmosphere
-        //  - Very cold
-        //  - Water Level of 2
-        ArrayList<String> frozenTypeChangeProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyNotFrozenWorld,
-                colonyAtmosphericDensityNormal,
-                colonyVeryCold,
-                colonyHasLargeWaterPresent
-        ));
-
-        // Requires:
-        //  - Planet type permits improvement in farmland
-        //  - Normal atmosphere
-        //  - Atmosphere is not toxic or irradiated
-        //  - Water Level of 2
-        ArrayList<String> farmlandResourceImprovementProjectReq = new ArrayList<>(asList(
-                worldTypeSupportsFarmlandImprovement,
-                colonyAtmosphericDensityNormal,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyHasLargeWaterPresent
-        ));
-
-        // Requires:
-        //  - Planet type permits improvement in organics
-        ArrayList<String> organicsResourceImprovementProjectReq = new ArrayList<>(asList(
-                worldTypeSupportsOrganicsImprovement
-        ));
-
-        // Requires:
-        //  - Planet type permits improvement in volatiles
-        ArrayList<String> volatilesResourceImprovementProjectReq = new ArrayList<>(asList(
-                worldTypeSupportsVolatilesImprovement
-        ));
-
-        // Requires:
-        //  - Market has Extreme Weather
-        //  - Planet can be terraformed
-        //  - Market has normal atmosphere
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> extremeWeatherConditionImprovementProjectReq = new ArrayList<>(asList(
-                worldTypeAllowsTerraforming,
-                colonyExtremeWeather,
-                colonyAtmosphericDensityNormal,
-                colonyHasAtmosphereProcessor
-        ));
-
-        // Requires:
-        //  - Market lacks Extreme Weather and Mild Climate
-        //  - Market is habitable
-        //  - World is Earth-like type
-        //  - Market has normal atmosphere
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> mildClimateConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyNormalClimate,
-                colonyHabitable,
-                worldTypeAllowsMildClimate,
-                colonyAtmosphericDensityNormal,
-                colonyHasAtmosphereProcessor
-        ));
-
-        // Requires:
-        //  - Market is not already habitable
-        //  - World is Earth-like type
-        //  - Market has normal atmosphere
-        //  - Not very cold or very hot temperature
-        //  - Atmosphere is not toxic or irradiated
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> habitableConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyNotAlreadyHabitable,
-                worldTypeAllowsHumanHabitability,
-                colonyAtmosphericDensityNormal,
-                colonyNotVeryColdOrVeryHot,
-                colonyAtmosphereNotToxicOrIrradiated,
-                colonyHasAtmosphereProcessor
-        ));
-
-        // Requires:
-        //  - Market has atmosphere problem(s)
-        //  - Planet can be terraformed
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> atmosphereDensityConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyAtmosphereSuboptimalDensity,
-                worldTypeAllowsTerraforming,
-                colonyHasAtmosphereProcessor
-        ));
-
-        // Requires:
-        //  - Market has atmosphere problem(s)
-        //  - Planet can be terraformed
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> toxicAtmosphereConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyAtmosphereToxic,
-                worldTypeAllowsTerraforming,
-                colonyHasAtmosphereProcessor
-        ));
-
-        // Requires:
-        //  - Market is irradiated
-        //  - Market has operational Genelab
-        ArrayList<String> irradiatedConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyIrradiated,
-                colonyHasGenelab
-        ));
-
-        // Requires:
-        //  - Market has an atmosphere
-        //  - Planet can be terraformed
-        //  - Market has operational Atmosphere Processor
-        ArrayList<String> removeAtmosphereConditionImprovementProjectReq = new ArrayList<>(asList(
-                colonyHasAtmosphere,
-                colonyBarrenOrFrozen,
-                colonyHasAtmosphereProcessor
-        ));
-
-        if(aotd_Enabled) {
-            // AotD requirements go here, just .add the display string here
-            // Type change -> "Researched: Terraforming Templates"
-            // Condition improvement -> "Researched : Atmosphere Manipulation"
-            // Resource improvement -> "Researched : Advanced Terraforming Templates"
-
-            aridTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-            jungleTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-            terranTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-            waterTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-            tundraTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-            frozenTypeChangeProjectReq.add(aotd_TypeChangeResearchRequirement);
-
-            farmlandResourceImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            organicsResourceImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            volatilesResourceImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-
-            extremeWeatherConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            mildClimateConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            habitableConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            atmosphereDensityConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            toxicAtmosphereConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            irradiatedConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-            removeAtmosphereConditionImprovementProjectReq.add(aotd_ResourceImprovementResearchRequirement);
-        }
-
-        // Type changes
-        ret.put(aridTypeChangeProjectID, aridTypeChangeProjectReq.toArray(new String[0]));
-        ret.put(jungleTypeChangeProjectID, jungleTypeChangeProjectReq.toArray(new String[0]));
-        ret.put(terranTypeChangeProjectID, terranTypeChangeProjectReq.toArray(new String[0]));
-        ret.put(waterTypeChangeProjectID, waterTypeChangeProjectReq.toArray(new String[0]));
-        ret.put(tundraTypeChangeProjectID, tundraTypeChangeProjectReq.toArray(new String[0]));
-        ret.put(frozenTypeChangeProjectID, frozenTypeChangeProjectReq.toArray(new String[0]));
-
-        // Resource improvements
-        ret.put(farmlandResourceImprovementProjectID, farmlandResourceImprovementProjectReq.toArray(new String[0]));
-        ret.put(organicsResourceImprovementProjectID, organicsResourceImprovementProjectReq.toArray(new String[0]));
-        ret.put(volatilesResourceImprovementProjectID, volatilesResourceImprovementProjectReq.toArray(new String[0]));
-
-        // Condition improvements
-        ret.put(extremeWeatherConditionImprovementProjectID, extremeWeatherConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(mildClimateConditionImprovementProjectID, mildClimateConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(habitableConditionImprovementProjectID, habitableConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(atmosphereDensityConditionImprovementProjectID, atmosphereDensityConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(toxicAtmosphereConditionImprovementProjectID, toxicAtmosphereConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(irradiatedConditionImprovementProjectID, irradiatedConditionImprovementProjectReq.toArray(new String[0]));
-        ret.put(removeAtmosphereConditionImprovementProjectID, removeAtmosphereConditionImprovementProjectReq.toArray(new String[0]));
-
-        return ret;
-    }
-
-    private static HashMap<String, String> initialiseProjectTooltips() {
-        HashMap<String, String> ret = new HashMap<>();
-
-        ret.put(jungleTypeChangeProjectID, "Jungle type change");
-        ret.put(aridTypeChangeProjectID, "Arid type change");
-        ret.put(terranTypeChangeProjectID, "Terran type change");
-        ret.put(waterTypeChangeProjectID, "Water type change");
-        ret.put(tundraTypeChangeProjectID, "Tundra type change");
-        ret.put(frozenTypeChangeProjectID, "Frozen type change");
-
-        ret.put(farmlandResourceImprovementProjectID, "Farmland resource improvement");
-        ret.put(organicsResourceImprovementProjectID, "Organics resource improvement");
-        ret.put(volatilesResourceImprovementProjectID, "Volatiles resource improvement");
-
-        ret.put(extremeWeatherConditionImprovementProjectID, "Stabilize weather patterns");
-        ret.put(mildClimateConditionImprovementProjectID, "Make climate mild");
-        ret.put(habitableConditionImprovementProjectID, "Make atmosphere habitable");
-        ret.put(atmosphereDensityConditionImprovementProjectID, "Normalize atmospheric density");
-        ret.put(toxicAtmosphereConditionImprovementProjectID, "Reduce atmosphere toxicity");
-        ret.put(radiationConditionImprovementProjectID, "Eliminate harmful radiation");
-        ret.put(removeAtmosphereConditionImprovementProjectID, "Remove the atmosphere");
-
-        return ret;
-    }
+    public static final String craftCorruptedNanoforgeProjectTooltip = "Craft Corrupted Nanoforge";
+    public static final String craftPristineNanoforgeProjectTooltip = "Craft Pristine Nanoforge";
+    public static final String craftSynchrotronProjectTooltip = "Craft Synchrotron";
+    public static final String craftHypershuntTapProjectTooltip = "Craft Hypershunt Tap";
+    public static final String craftCryoarithmeticEngineProjectTooltip = "Craft Cryoarithmetic Engine";
+    public static final String craftPlanetKillerDeviceProjectTooltip = "Craft Planet Killer Device";
+    public static final String craftFusionLampProjectTooltip = "Craft Fusion Lamp";
+    public static final String craftFullereneSpoolProjectTooltip = "Craft Fullerene Spool";
+    public static final String craftPlasmaDynamoProjectTooltip = "Craft Plasma Dynamo";
+    public static final String craftAutonomousMantleBoreProjectTooltip = "Craft Autonomous Mantle Bore";
+    public static final String craftSoilNanitesProjectTooltip = "Craft Soil Nanites";
+    public static final String craftCatalyticCoreProjectTooltip = "Craft Catalytic Core";
+    public static final String craftCombatDroneReplicatorProjectTooltip = "Craft Combat Drone Replicator";
+    public static final String craftBiofactoryEmbryoProjectTooltip = "Craft Biofactory Embryo";
+    public static final String craftDealmakerHolosuiteProjectTooltip = "Craft Dealmaker Holosuite";
 
     private static HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> initialisePlanetTypeChangeConditions() {
         // one is conditions added, two is conditions removed
@@ -674,12 +448,570 @@ public class boggledTools
         return ret;
     }
 
-    private static final HashMap<String, String[]> projectRequirements = initialiseProjectRequirements();
+    private static ArrayList<TerraformingProject> initialiseTerraformingProjects() {
+        ArrayList<TerraformingProject> ret = new ArrayList<>();
 
-    private static final HashMap<String, String> projectTooltip = initialiseProjectTooltips();
+        TerraformingRequirements colonyNotAridWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotAridWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true, desertPlanetID)
+        )));
+
+        TerraformingRequirements colonyNotJungleWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotJungleWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true,junglePlanetID)
+        )));
+
+        TerraformingRequirements colonyNotTerranWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotTerranWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true, terranPlanetID)
+        )));
+
+        TerraformingRequirements colonyNotWaterWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotWaterWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true, waterPlanetID)
+        )));
+
+        TerraformingRequirements colonyNotTundraWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotTundraWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true, tundraPlanetID)
+        )));
+
+        TerraformingRequirements colonyNotFrozenWorld = new TerraformingRequirements(BoggledProjectRequirements.colonyNotFrozenWorld, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(true, frozenPlanetID)
+        )));
+
+        TerraformingRequirements colonyBarrenOrFrozen = new TerraformingRequirements(BoggledProjectRequirements.colonyBarrenOrFrozen, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(false, barrenPlanetID),
+                new PlanetTypeRequirement(false, frozenPlanetID)
+        )));
+
+        TerraformingRequirements colonyAtmosphericDensityNormal = new TerraformingRequirements(BoggledProjectRequirements.colonyAtmosphericDensityNormal, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.NO_ATMOSPHERE),
+                new MarketHasCondition(false, Conditions.THIN_ATMOSPHERE),
+                new MarketHasCondition(false, Conditions.DENSE_ATMOSPHERE)
+        )));
+
+        TerraformingRequirements colonyAtmosphereNotToxicOrIrradiated = new TerraformingRequirements(BoggledProjectRequirements.colonyAtmosphereNotToxicOrIrradiated, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.TOXIC_ATMOSPHERE),
+                new MarketHasCondition(false, Conditions.IRRADIATED)
+        )));
+
+        TerraformingRequirements colonyNotColdOrVeryCold = new TerraformingRequirements(BoggledProjectRequirements.colonyNotColdOrVeryCold, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.COLD),
+                new MarketHasCondition(false, Conditions.VERY_COLD)
+        )));
+
+        TerraformingRequirements colonyHotOrVeryHot = new TerraformingRequirements(BoggledProjectRequirements.colonyHotOrVeryHot, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.HOT),
+                new MarketHasCondition(false, Conditions.VERY_HOT)
+        )));
+
+        TerraformingRequirements colonyNotVeryColdOrVeryHot = new TerraformingRequirements(BoggledProjectRequirements.colonyNotVeryColdOrVeryHot, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.VERY_COLD),
+                new MarketHasCondition(false, Conditions.VERY_HOT)
+        )));
+
+        TerraformingRequirements colonyNotHotOrVeryHot = new TerraformingRequirements(BoggledProjectRequirements.colonyNotHotOrVeryHot, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.HOT),
+                new MarketHasCondition(false, Conditions.VERY_HOT)
+        )));
+
+        TerraformingRequirements colonyVeryCold = new TerraformingRequirements(BoggledProjectRequirements.colonyVeryCold, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.VERY_COLD)
+        )));
+
+        TerraformingRequirements colonyTemperateOrHot = new TerraformingRequirements(BoggledProjectRequirements.colonyTemperateOrHot, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.VERY_COLD),
+                new MarketHasCondition(false, Conditions.COLD),
+                new MarketHasCondition(false, Conditions.VERY_HOT)
+        )));
+
+        TerraformingRequirements colonyTemperateOrCold = new TerraformingRequirements(BoggledProjectRequirements.colonyTemperateOrCold, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.VERY_COLD),
+                new MarketHasCondition(false, Conditions.HOT),
+                new MarketHasCondition(false, Conditions.VERY_HOT)
+        )));
+
+        TerraformingRequirements colonyHasStellarReflectors = new TerraformingRequirements(BoggledProjectRequirements.colonyHasStellarReflectors, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.SOLAR_ARRAY)
+        )));
+
+        TerraformingRequirements colonyHasModerateWaterPresent = new TerraformingRequirements(BoggledProjectRequirements.colonyHasModerateWaterPresent, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasWaterPresent(false, 1, 2)
+        )));
+
+        TerraformingRequirements colonyHasLargeWaterPresent = new TerraformingRequirements(BoggledProjectRequirements.colonyHasLargeWaterPresent, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasWaterPresent(false, 2, 2)
+        )));
+
+        TerraformingRequirements colonyHasAtmosphereProcessor = new TerraformingRequirements(BoggledProjectRequirements.colonyHasAtmosphereProcessor, false,new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasIndustry(false, BoggledIndustries.atmosphereProcessorIndustryID)
+        )));
+
+        TerraformingRequirements colonyHasGenelab = new TerraformingRequirements(BoggledProjectRequirements.colonyHasGenelab, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasIndustry(false, BoggledIndustries.genelabIndustryID)
+        )));
+
+        TerraformingRequirements colonyHabitable = new TerraformingRequirements(BoggledProjectRequirements.colonyHabitable, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.HABITABLE)
+        )));
+
+        TerraformingRequirements colonyNotAlreadyHabitable = new TerraformingRequirements(BoggledProjectRequirements.colonyNotAlreadyHabitable, false,new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(true, Conditions.HABITABLE)
+        )));
+
+        TerraformingRequirements colonyExtremeWeather = new TerraformingRequirements(BoggledProjectRequirements.colonyExtremeWeather, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.EXTREME_WEATHER)
+        )));
+
+        TerraformingRequirements colonyNormalClimate = new TerraformingRequirements(BoggledProjectRequirements.colonyNormalClimate, true, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.MILD_CLIMATE),
+                new MarketHasCondition(false, Conditions.EXTREME_WEATHER)
+        )));
+
+        TerraformingRequirements colonyAtmosphereToxic = new TerraformingRequirements(BoggledProjectRequirements.colonyAtmosphereToxic, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.TOXIC_ATMOSPHERE)
+        )));
+
+        TerraformingRequirements colonyIrradiated = new TerraformingRequirements(BoggledProjectRequirements.colonyIrradiated, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.IRRADIATED)
+        )));
+
+        TerraformingRequirements colonyHasAtmosphere = new TerraformingRequirements(BoggledProjectRequirements.colonyHasAtmosphere, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(true, Conditions.NO_ATMOSPHERE)
+        )));
+
+        TerraformingRequirements colonyAtmosphereSuboptimalDensity = new TerraformingRequirements(BoggledProjectRequirements.colonyAtmosphereSuboptimalDensity, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasCondition(false, Conditions.NO_ATMOSPHERE),
+                new MarketHasCondition(false, Conditions.THIN_ATMOSPHERE),
+                new MarketHasCondition(false, Conditions.DENSE_ATMOSPHERE)
+        )));
+
+        TerraformingRequirements worldTypeSupportsFarmlandImprovement = new TerraformingRequirements(BoggledProjectRequirements.worldTypeSupportsFarmlandImprovement, false, new ArrayList<TerraformingRequirement>(asList(
+                new WorldTypeSupportsResourceImprovement(false, BoggledResources.farmlandResourceID)
+        )));
+
+        TerraformingRequirements worldTypeSupportsOrganicsImprovement = new TerraformingRequirements(BoggledProjectRequirements.worldTypeSupportsOrganicsImprovement, false, new ArrayList<TerraformingRequirement>(asList(
+                new WorldTypeSupportsResourceImprovement(false, BoggledResources.organicsResourceID)
+        )));
+
+        TerraformingRequirements worldTypeSupportsVolatilesImprovement = new TerraformingRequirements(BoggledProjectRequirements.worldTypeSupportsVolatilesImprovement, false, new ArrayList<TerraformingRequirement>(asList(
+                new WorldTypeSupportsResourceImprovement(false, BoggledResources.volatilesResourceID)
+        )));
+
+        TerraformingRequirements worldTypeAllowsTerraforming = new TerraformingRequirements(BoggledProjectRequirements.worldTypeAllowsTerraforming, true, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(false, starPlanetID),
+                new PlanetTypeRequirement(false, gasGiantPlanetID),
+                new PlanetTypeRequirement(false, volcanicPlanetID),
+                new PlanetTypeRequirement(false, unknownPlanetID)
+        )));
+
+        TerraformingRequirements worldTypeAllowsMildClimate = new TerraformingRequirements(BoggledProjectRequirements.worldTypeAllowsMildClimate, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(false, junglePlanetID),
+                new PlanetTypeRequirement(false, desertPlanetID),
+                new PlanetTypeRequirement(false, terranPlanetID),
+                new PlanetTypeRequirement(false, waterPlanetID),
+                new PlanetTypeRequirement(false, tundraPlanetID)
+        )));
+
+        TerraformingRequirements worldTypeAllowsHumanHabitability = new TerraformingRequirements(BoggledProjectRequirements.worldTypeAllowsHumanHabitability, false, new ArrayList<TerraformingRequirement>(asList(
+                new PlanetTypeRequirement(false, junglePlanetID),
+                new PlanetTypeRequirement(false, desertPlanetID),
+                new PlanetTypeRequirement(false, terranPlanetID),
+                new PlanetTypeRequirement(false, waterPlanetID),
+                new PlanetTypeRequirement(false, tundraPlanetID)
+        )));
+
+        // Type change projects
+        // Requires:
+        //  - Not already arid
+        //  - Normal atmosphere
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Colony is temperate or hot
+        //  - Stellar Reflectors
+        //  - Water Level of 1
+        ret.add(new TerraformingProject(aridTypeChangeProjectID, aridTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotAridWorld,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyTemperateOrHot,
+                colonyHasStellarReflectors,
+                colonyHasModerateWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Arid world starting resources:",
+                "          - Adequate farmland, common organics, no volatiles",
+                "      - Arid world maximum resources:",
+                "          - Bountiful farmland, abundant organics, trace volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Requires:
+        //  - Not already jungle
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Colony is temperate or hot
+        //  - Stellar Reflectors
+        //  - Water Level of 1
+        ret.add(new TerraformingProject(jungleTypeChangeProjectID, jungleTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotJungleWorld,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyTemperateOrHot,
+                colonyHasStellarReflectors,
+                colonyHasModerateWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Jungle world starting resources:",
+                "          - Adequate farmland, common organics, no volatiles",
+                "      - Jungle world maximum resources:",
+                "          - Bountiful farmland, plentiful organics, no volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Requires:
+        //  - Not already Terran
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Not very cold or very hot temperature
+        //  - Stellar Reflectors
+        //  - Water Level of 1
+        ret.add(new TerraformingProject(terranTypeChangeProjectID, terranTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotTerranWorld,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyNotVeryColdOrVeryHot,
+                colonyHasStellarReflectors,
+                colonyHasModerateWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Terran world starting resources:",
+                boggledTools.getBooleanSetting(BoggledSettings.terraformingTypeChangeAddVolatiles) ?
+                    "          - Adequate farmland, trace organics, trace volatiles" :
+                    "          - Adequate farmland, trace organics, no volatiles",
+                "      - Terran world maximum resources:",
+                "          - Bountiful farmland, plentiful organics, trace volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Requires:
+        //  - Not already water
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Not very cold or very hot temperature
+        //  - Stellar Reflectors
+        //  - Water Level of 2
+        ret.add(new TerraformingProject(waterTypeChangeProjectID, waterTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotWaterWorld,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyNotVeryColdOrVeryHot,
+                colonyHasStellarReflectors,
+                colonyHasLargeWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Water world starting resources:",
+                "          - No organics, no volatiles",
+                "      - Water world maximum resources:",
+                "          - Plentiful organics, plentiful volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Requires:
+        //  - Not already tundra
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Colony is temperate or cold
+        //  - Stellar Reflectors
+        //  - Water Level of 1
+        ret.add(new TerraformingProject(tundraTypeChangeProjectID, tundraTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotTundraWorld,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyTemperateOrCold,
+                colonyHasStellarReflectors,
+                colonyHasModerateWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Tundra world starting resources:",
+                boggledTools.getBooleanSetting(BoggledSettings.terraformingTypeChangeAddVolatiles) ?
+                    "          - Adequate farmland, trace organics, trace volatiles" :
+                    "          - Adequate farmland, trace organics, no volatiles",
+                "      - Tundra world maximum resources:",
+                "          - Bountiful farmland, trace organics, plentiful volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Requires:
+        //  - Not already frozen
+        //  - Normal atmosphere
+        //  - Very cold
+        //  - Water Level of 2
+        ret.add(new TerraformingProject(frozenTypeChangeProjectID, frozenTypeChangeProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyNotFrozenWorld,
+                colonyAtmosphericDensityNormal,
+                colonyVeryCold,
+                colonyHasLargeWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Frozen world starting resources:",
+                "          - No farmland, no organics, abundant volatiles",
+                "      - Frozen world maximum resources:",
+                "          - No farmland, no organics, plentiful volatiles",
+                "      - Ore deposits are unaffected"
+        ))));
+
+        // Resource improvement projects
+        // Requires:
+        //  - Planet type permits improvement in farmland
+        //  - Normal atmosphere
+        //  - Atmosphere is not toxic or irradiated
+        //  - Water Level of 2
+        ret.add(new TerraformingProject(farmlandResourceImprovementProjectID, farmlandResourceImprovementProjectTooltip, new ArrayList<>(asList(
+                worldTypeSupportsFarmlandImprovement,
+                colonyAtmosphericDensityNormal,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyHasLargeWaterPresent
+        )), new ArrayList<>(asList(
+                "      - Farming yield improved by one"
+        ))));
+
+        // Requires:
+        //  - Planet type permits improvement in organics
+        ret.add(new TerraformingProject(organicsResourceImprovementProjectID, organicsResourceImprovementProjectTooltip, new ArrayList<>(asList(
+                worldTypeSupportsOrganicsImprovement
+        )), new ArrayList<>(asList(
+                "      - Organics yield improved by one"
+        ))));
+
+        // Requires:
+        //  - Planet type permits improvement in volatiles
+        ret.add(new TerraformingProject(volatilesResourceImprovementProjectID, volatilesResourceImprovementProjectTooltip, new ArrayList<>(asList(
+                worldTypeSupportsVolatilesImprovement
+        )), new ArrayList<>(asList(
+                "      - Volatiles yield improved by one"
+        ))));
+
+        // Condition improvement projects
+        // Requires:
+        //  - Market has Extreme Weather
+        //  - Planet can be terraformed
+        //  - Market has normal atmosphere
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(extremeWeatherConditionImprovementProjectID, extremeWeatherConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                worldTypeAllowsTerraforming,
+                colonyExtremeWeather,
+                colonyAtmosphericDensityNormal,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Extreme weather patterns remediated"
+        ))));
+
+        // Requires:
+        //  - Market lacks Extreme Weather and Mild Climate
+        //  - Market is habitable
+        //  - World is Earth-like type
+        //  - Market has normal atmosphere
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(mildClimateConditionImprovementProjectID, mildClimateConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyNormalClimate,
+                colonyHabitable,
+                worldTypeAllowsMildClimate,
+                colonyAtmosphericDensityNormal,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Climate made mild"
+        ))));
+
+        // Requires:
+        //  - Market is not already habitable
+        //  - World is Earth-like type
+        //  - Market has normal atmosphere
+        //  - Not very cold or very hot temperature
+        //  - Atmosphere is not toxic or irradiated
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(habitableConditionImprovementProjectID, habitableConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyNotAlreadyHabitable,
+                worldTypeAllowsHumanHabitability,
+                colonyAtmosphericDensityNormal,
+                colonyNotVeryColdOrVeryHot,
+                colonyAtmosphereNotToxicOrIrradiated,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Atmosphere made human-breathable"
+        ))));
+
+        // Requires:
+        //  - Market has atmosphere problem(s)
+        //  - Planet can be terraformed
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(atmosphereDensityConditionImprovementProjectID, atmosphereDensityConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyAtmosphereSuboptimalDensity,
+                worldTypeAllowsTerraforming,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Atmosphere with Earth-like density created"
+        ))));
+
+        // Requires:
+        //  - Market has atmosphere problem(s)
+        //  - Planet can be terraformed
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(toxicAtmosphereConditionImprovementProjectID, toxicAtmosphereConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyAtmosphereToxic,
+                worldTypeAllowsTerraforming,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Atmospheric toxicity remediated"
+        ))));
+
+        // Requires:
+        //  - Market is irradiated
+        //  - Market has operational Genelab
+        ret.add(new TerraformingProject(irradiatedConditionImprovementProjectID, irradiatedConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyIrradiated,
+                colonyHasGenelab
+        )), new ArrayList<>(asList(
+                "      - Atmospheric radiation remediated"
+        ))));
+
+        // Requires:
+        //  - Market has an atmosphere
+        //  - Planet can be terraformed
+        //  - Market has operational Atmosphere Processor
+        ret.add(new TerraformingProject(removeAtmosphereConditionImprovementProjectID, removeAtmosphereConditionImprovementProjectTooltip, new ArrayList<>(asList(
+                colonyHasAtmosphere,
+                colonyBarrenOrFrozen,
+                colonyHasAtmosphereProcessor
+        )), new ArrayList<>(asList(
+                "      - Atmosphere removed"
+        ))));
+
+        // Crafting projects
+        // They're in a separate collection right now
+        // Maybe once this is all sorted, they can be merged with a new requirement, like "Must be within this distance of the chosen planet"
+
+        return ret;
+    }
+
+    private static ArrayList<TerraformingProject> initialiseCraftingProjects() {
+        ArrayList<TerraformingProject> ret = new ArrayList<>();
+
+        TerraformingRequirements colonyHasAtLeast100kInhabitants = new TerraformingRequirements(BoggledProjectRequirements.colonyHasAtLeast100kInhabitants, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketIsAtLeastSize(false, 5)
+        )));
+
+        TerraformingRequirements colonyHasOrbitalWorksWPristineNanoforge = new TerraformingRequirements(BoggledProjectRequirements.colonyHasOrbitalWorksWPristineNanoforge, false, new ArrayList<TerraformingRequirement>(asList(
+                new MarketHasIndustryWithItem(false, Industries.ORBITALWORKS, Items.PRISTINE_NANOFORGE)
+        )));
+
+        int domainArtifactCostMedium = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingArtifactCost);
+        int domainArtifactCostHard = domainArtifactCostMedium * 2;
+        int domainArtifactCostEasy = domainArtifactCostMedium / 2;
+        TerraformingRequirements fleetCargoContainsAtLeastDomainArtifactsEasy = new TerraformingRequirements("Fleet cargo contains at least " + domainArtifactCostEasy + " Domain-era artifacts", false, new ArrayList<TerraformingRequirement>(asList(
+                new FleetCargoContainsAtLeast(false, BoggledCommodities.domainArtifacts, domainArtifactCostEasy)
+        )));
+
+        TerraformingRequirements fleetCargoContainsAtLeastDomainArtifactsMedium = new TerraformingRequirements("Fleet cargo contains at least " + domainArtifactCostMedium + " Domain-era artifacts", false, new ArrayList<TerraformingRequirement>(asList(
+                new FleetCargoContainsAtLeast(false, BoggledCommodities.domainArtifacts, domainArtifactCostMedium)
+        )));
+
+        TerraformingRequirements fleetCargoContainsAtLeastDomainArtifactsHard = new TerraformingRequirements("Fleet cargo contains at least " + domainArtifactCostHard + " Domain-era artifacts", false, new ArrayList<TerraformingRequirement>(asList(
+                new FleetCargoContainsAtLeast(false, BoggledCommodities.domainArtifacts, domainArtifactCostHard)
+        )));
+
+        int storyPointCost = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost);
+        TerraformingRequirements playerHasStoryPointsAtLeast = new TerraformingRequirements(storyPointCost + " story points available to spend", false, new ArrayList<TerraformingRequirement>(asList(
+                new PlayerHasStoryPointsAtLeast(false, storyPointCost)
+        )));
+
+        ArrayList<TerraformingRequirements> craftingProjectReqsEasy = new ArrayList<>(asList(
+                colonyHasAtLeast100kInhabitants,
+                colonyHasOrbitalWorksWPristineNanoforge,
+                fleetCargoContainsAtLeastDomainArtifactsEasy
+        ));
+
+        ArrayList<TerraformingRequirements> craftingProjectReqsMedium = new ArrayList<>(asList(
+                colonyHasAtLeast100kInhabitants,
+                colonyHasOrbitalWorksWPristineNanoforge,
+                fleetCargoContainsAtLeastDomainArtifactsMedium
+        ));
+
+        ArrayList<TerraformingRequirements> craftingProjectReqsHard = new ArrayList<>(asList(
+                colonyHasAtLeast100kInhabitants,
+                colonyHasOrbitalWorksWPristineNanoforge,
+                fleetCargoContainsAtLeastDomainArtifactsHard
+        ));
+
+        if (storyPointCost > 0) {
+            craftingProjectReqsEasy.add(playerHasStoryPointsAtLeast);
+            craftingProjectReqsMedium.add(playerHasStoryPointsAtLeast);
+            craftingProjectReqsHard.add(playerHasStoryPointsAtLeast);
+        }
+
+        ArrayList<String> emptyList = new ArrayList<>();
+
+        ret.add(new TerraformingProject(craftCorruptedNanoforgeProjectID, craftCorruptedNanoforgeProjectTooltip, craftingProjectReqsEasy, emptyList));
+
+        ret.add(new TerraformingProject(craftPristineNanoforgeProjectID, craftPristineNanoforgeProjectTooltip, craftingProjectReqsHard, emptyList));
+
+        ret.add(new TerraformingProject(craftSynchrotronProjectID, craftSynchrotronProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftHypershuntTapProjectID, craftHypershuntTapProjectTooltip, craftingProjectReqsHard, emptyList));
+
+        ret.add(new TerraformingProject(craftCryoarithmeticEngineProjectID, craftCryoarithmeticEngineProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftPlanetKillerDeviceProjectID, craftPlanetKillerDeviceProjectTooltip, craftingProjectReqsHard, emptyList));
+
+        ret.add(new TerraformingProject(craftFusionLampProjectID, craftFusionLampProjectTooltip, craftingProjectReqsHard, emptyList));
+
+        ret.add(new TerraformingProject(craftFullereneSpoolProjectID, craftFullereneSpoolProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftPlasmaDynamoProjectID, craftPlasmaDynamoProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftAutonomousMantleBoreProjectID, craftAutonomousMantleBoreProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftSoilNanitesProjectID, craftSoilNanitesProjectTooltip, craftingProjectReqsMedium,emptyList ));
+
+        ret.add(new TerraformingProject(craftCatalyticCoreProjectID, craftCatalyticCoreProjectTooltip, craftingProjectReqsMedium,emptyList ));
+
+        ret.add(new TerraformingProject(craftCombatDroneReplicatorProjectID, craftCombatDroneReplicatorProjectTooltip, craftingProjectReqsEasy,emptyList ));
+
+        ret.add(new TerraformingProject(craftBiofactoryEmbryoProjectID, craftBiofactoryEmbryoProjectTooltip, craftingProjectReqsMedium, emptyList));
+
+        ret.add(new TerraformingProject(craftDealmakerHolosuiteProjectID, craftDealmakerHolosuiteProjectTooltip, craftingProjectReqsEasy, emptyList));
+
+        return ret;
+    }
+
+    private static TerraformingProject getProject(String projectId) {
+        for (TerraformingProject project : terraformingProjects) {
+            if (project.projectId.equals(projectId)) {
+                return project;
+            }
+        }
+        return null;
+    }
+
+    public static TerraformingProject getCraftingProject(String projectId) {
+        for (TerraformingProject project : craftingProjects) {
+            if (project.projectId.equals(projectId)) {
+                return project;
+            }
+        }
+        return null;
+    }
 
     // one is conditions added, two is conditions removed
-    private static final HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> planetTypeChangeConditions = initialisePlanetTypeChangeConditions();
+    private static HashMap<String, Pair<ArrayList<String>, ArrayList<String>>> planetTypeChangeConditions = initialisePlanetTypeChangeConditions();
+
+    private static ArrayList<TerraformingProject> terraformingProjects = initialiseTerraformingProjects();
+    private static ArrayList<TerraformingProject> craftingProjects = initialiseCraftingProjects();
+
+    public static ArrayList<TerraformingProject> getTerraformingProjects() { return terraformingProjects; }
+
+    private static void reinitialiseInfo() {
+        planetTypeChangeConditions = initialisePlanetTypeChangeConditions();
+
+        terraformingProjects = initialiseTerraformingProjects();
+        craftingProjects = initialiseCraftingProjects();
+    }
 
     public static float getDistanceBetweenPoints(float x1, float y1, float x2, float y2) {
         return (float) Math.sqrt((y2 - y1) * (y2 - y1) + (x2 - x1) * (x2 - x1));
@@ -1494,7 +1826,7 @@ public class boggledTools
         Iterator<SectorEntityToken> allEntitiesInSystem = market.getStarSystem().getAllEntities().iterator();
         while(allEntitiesInSystem.hasNext())
         {
-            SectorEntityToken entity = (SectorEntityToken)allEntitiesInSystem.next();
+            SectorEntityToken entity = allEntitiesInSystem.next();
             if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(market.getPrimaryEntity()) && (entity.getId().contains(Entities.STELLAR_MIRROR) || entity.getId().contains(Entities.STELLAR_SHADE) || entity.hasTag(Entities.STELLAR_MIRROR) || entity.hasTag(Entities.STELLAR_SHADE)))
             {
                 allEntitiesInSystem.remove();
@@ -1524,7 +1856,7 @@ public class boggledTools
             orbit = station.getOrbit();
         }
         CampaignClockAPI clock = Global.getSector().getClock();
-        SectorEntityToken newStation = null;
+        SectorEntityToken newStation;
         SectorEntityToken newStationLights = null;
 
         String size = "null";
@@ -2426,6 +2758,7 @@ public class boggledTools
 
         market.getPlanetEntity().changeType(newPlanetType.replace("TypeChange",""), null);
 
+        reinitialiseInfo();
         Pair<ArrayList<String>, ArrayList<String>> conditionsAddedRemoved = planetTypeChangeConditions.get(newPlanetType);
         if (conditionsAddedRemoved != null) {
             for (String addedCondition : conditionsAddedRemoved.one) {
@@ -2450,304 +2783,272 @@ public class boggledTools
         }
     }
 
-    public static String[] getProjectRequirementsStrings(String project)
-    {
-        String[] requirements = projectRequirements.get(project);
-        if (requirements != null)
-        {
-            return requirements;
-        }
-
-        else if(project.contains("Crafting"))
-        {
-            // For now, all the special items require the same conditions to craft.
-
-            // Requires:
-            //  - Market is size 5 or larger
-            //  - Market has operational Orbital Works with Pristine Nanoforge installed
-
-            int artifactCost = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingArtifactCost);
-            int storyPointCost = boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost);
-            int adjustedArtifactCost = 0;
-            if(project.contains("Hard"))
-            {
-                adjustedArtifactCost = artifactCost * 2;
+    public static String[] getProjectRequirementsStrings(TerraformingProject terraformingProject) {
+        ArrayList<String> ret = new ArrayList<>();
+        if (terraformingProject != null) {
+            for (TerraformingRequirements requirement : terraformingProject.projectRequirements) {
+                ret.add(requirement.tooltip);
             }
-            else if(project.contains("Medium"))
-            {
-                adjustedArtifactCost = artifactCost;
-            }
-            else if(project.contains("Easy"))
-            {
-                adjustedArtifactCost = artifactCost / 2;
-            }
-
-            ArrayList<String> reqs = new ArrayList<>(asList(
-                colonyHasAtLeast100kInhabitants,
-                colonyHasOrbitalWorksWPristineNanoforge,
-                "Fleet cargo contains at least " + adjustedArtifactCost + " Domain-era artifacts"
-            ));
-
-            if(storyPointCost > 0)
-            {
-                reqs.add(storyPointCost + " story points available to spend");
-            }
-            return reqs.toArray(new String[0]);
+            return ret.toArray(new String[0]);
         }
 
         // Should never be reached unless bad project string passed in.
         return new String[]{"You should never see this text. If you do, tell Boggled about it on the forums."};
     }
 
-    public static boolean requirementMet(MarketAPI market, String requirement)
+    public static String[] getProjectRequirementsStrings(String project)
     {
-        PlanetAPI planet = null;
-        String planetType = "";
-        int planetWaterLevel = 0;
+        reinitialiseInfo();
+        TerraformingProject terraformingProject = getProject(project);
+        return getProjectRequirementsStrings(terraformingProject);
+    }
 
-        if(!boggledTools.marketIsStation(market))
-        {
-            planet = market.getPlanetEntity();
-            planetType = getPlanetType(planet);
-            planetWaterLevel = getPlanetWaterLevel(market);
+    public static class TerraformingProject {
+        private final String projectId;
+        private final String projectTooltip;
+        // Multiple separate TerraformingRequirements form an AND'd collection
+        // Each individual requirement inside the TerraformingRequirements forms an OR'd collection
+        // ie If any of the conditions inside a TerraformingRequirements is fulfilled, that entire requirement is filled
+        // But then all the TerraformingRequirements must be fulfilled for the project to be allowed
+        private final ArrayList<TerraformingRequirements> projectRequirements;
+
+        private final ArrayList<String> projectResults;
+
+        public String getProjectId() { return projectId; }
+        public String getProjectTooltip() { return projectTooltip; }
+
+        public ArrayList<TerraformingRequirements> getProjectRequirements() { return projectRequirements; }
+
+        TerraformingProject(String projectId, String projectTooltip, ArrayList<TerraformingRequirements> projectRequirements, ArrayList<String> projectResults) {
+            this.projectId = projectId;
+            this.projectTooltip = projectTooltip;
+            this.projectRequirements = projectRequirements;
+            this.projectResults = projectResults;
+        }
+    }
+
+    public static class TerraformingRequirements {
+        private final String tooltip;
+        private final boolean invertAll;
+        private final ArrayList<TerraformingRequirement> terraformingRequirements;
+
+        TerraformingRequirements(String tooltip, boolean invertAll, ArrayList<TerraformingRequirement> terraformingRequirements) {
+            this.tooltip = tooltip;
+            this.invertAll = invertAll;
+            this.terraformingRequirements = terraformingRequirements;
         }
 
-        if(requirement.equals("You should never see this text. If you do, tell Boggled about it on the forums."))
-        {
-            return false;
+        public final String getTooltip() { return tooltip; }
+
+        public final boolean checkRequirement(MarketAPI market) {
+            boolean requirementsMet = false;
+            for (TerraformingRequirement terraformingRequirement : terraformingRequirements) {
+                requirementsMet = requirementsMet || terraformingRequirement.checkRequirement(market);
+            }
+            if (invertAll) {
+                requirementsMet = !requirementsMet;
+            }
+            return requirementsMet;
         }
-        else if(requirement.equals(colonyNotAridWorld))
-        {
-            return !planetType.equals(desertPlanetID);
+    }
+
+    public abstract static class TerraformingRequirement {
+        private final boolean invert;
+
+        TerraformingRequirement(boolean invert) {
+            this.invert = invert;
         }
-        else if(requirement.equals(colonyNotJungleWorld))
-        {
-            return !planetType.equals(junglePlanetID);
+
+        protected abstract boolean checkRequirementImpl(MarketAPI market);
+
+        public final boolean checkRequirement(MarketAPI market) {
+            boolean ret = checkRequirementImpl(market);
+            if (invert) {
+                ret = !ret;
+            }
+            return ret;
         }
-        else if(requirement.equals(colonyNotTerranWorld))
-        {
-            return !planetType.equals(terranPlanetID);
+    }
+
+    public static class PlanetTypeRequirement extends TerraformingRequirement {
+        String planetTypeID;
+        PlanetTypeRequirement(Boolean invert, String planetTypeID) {
+            super(invert);
+            this.planetTypeID = planetTypeID;
         }
-        else if(requirement.equals(colonyNotWaterWorld))
-        {
-            return !planetType.equals(waterPlanetID);
+
+        @Override
+        protected final boolean checkRequirementImpl(MarketAPI market) {
+            return planetTypeID.equals(getPlanetType(market.getPlanetEntity()));
         }
-        else if(requirement.equals(colonyNotTundraWorld))
-        {
-            return !planetType.equals(tundraPlanetID);
+    }
+
+    public static class MarketHasCondition extends TerraformingRequirement {
+        String conditionID;
+        MarketHasCondition(boolean invert, String conditionID) {
+            super(invert);
+            this.conditionID = conditionID;
         }
-        else if(requirement.equals(colonyNotFrozenWorld))
-        {
-            return !planetType.equals(frozenPlanetID);
+
+        @Override
+        protected final boolean checkRequirementImpl(MarketAPI market) {
+            return market.hasCondition(conditionID);
         }
-        else if(requirement.equals(colonyBarrenOrFrozen))
-        {
-            return planetType.equals(barrenPlanetID) || planetType.equals(frozenPlanetID);
+    }
+
+    public static class MarketHasIndustry extends TerraformingRequirement {
+        String industryID;
+        MarketHasIndustry(boolean invert, String industryID) {
+            super(invert);
+            this.industryID = industryID;
         }
-        else if(requirement.equals(colonyAtmosphericDensityNormal))
-        {
-            if(market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE))
-            {
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            Industry industry = market.getIndustry(industryID);
+            return industry != null && industry.isFunctional() && market.hasIndustry(industryID);
+        }
+    }
+
+    public static class MarketHasIndustryWithItem extends TerraformingRequirement {
+        String industryID;
+        String itemID;
+        MarketHasIndustryWithItem(boolean invert, String industryID, String itemID) {
+            super(invert);
+            this.industryID = industryID;
+            this.itemID = itemID;
+        }
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            Industry industry = market.getIndustry(industryID);
+            if (industry == null) {
                 return false;
             }
-            else
-            {
-                return true;
-            }
-        }
-        else if(requirement.equals(colonyAtmosphereNotToxicOrIrradiated))
-        {
-            if(market.hasCondition(Conditions.TOXIC_ATMOSPHERE) || market.hasCondition(Conditions.IRRADIATED))
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
-        else if(requirement.equals(colonyNotColdOrVeryCold))
-        {
-            return !market.hasCondition(Conditions.COLD) && !market.hasCondition(Conditions.VERY_COLD);
-        }
-        else if(requirement.equals(colonyHotOrVeryHot))
-        {
-            return market.hasCondition(Conditions.HOT) || market.hasCondition(Conditions.VERY_HOT);
-        }
-        else if(requirement.equals(colonyNotVeryColdOrVeryHot))
-        {
-            return !market.hasCondition(Conditions.VERY_HOT) && !market.hasCondition(Conditions.VERY_COLD);
-        }
-        else if(requirement.equals(colonyNotHotOrVeryHot))
-        {
-            return !market.hasCondition(Conditions.HOT) && !market.hasCondition(Conditions.VERY_HOT);
-        }
-        else if(requirement.equals(colonyVeryCold))
-        {
-            return market.hasCondition(Conditions.VERY_COLD);
-        }
-        else if(requirement.equals(colonyTemperateOrHot))
-        {
-            return !market.hasCondition(Conditions.VERY_COLD) && !market.hasCondition(Conditions.COLD) && !market.hasCondition(Conditions.VERY_HOT);
-        }
-        else if(requirement.equals(colonyTemperateOrCold))
-        {
-            return !market.hasCondition(Conditions.VERY_COLD) && !market.hasCondition(Conditions.HOT) && !market.hasCondition(Conditions.VERY_HOT);
-        }
-        else if(requirement.equals(colonyHasStellarReflectors))
-        {
-            return marketHasStellarReflectorArray(market);
-        }
-        else if(requirement.equals(colonyHasModerateWaterPresent))
-        {
-            return planetWaterLevel == 1 || planetWaterLevel == 2;
-        }
-        else if(requirement.equals(colonyHasLargeWaterPresent))
-        {
-            return planetWaterLevel == 2;
-        }
-        else if(requirement.equals(colonyHasAtmosphereProcessor))
-        {
-            return marketHasAtmosphereProcessor(market);
-        }
-        else if(requirement.equals(colonyHasGenelab))
-        {
-            return marketHasGenelab(market);
-        }
-        else if(requirement.equals(colonyHabitable))
-        {
-            return market.hasCondition(Conditions.HABITABLE);
-        }
-        else if(requirement.equals(colonyNotAlreadyHabitable))
-        {
-            return !market.hasCondition(Conditions.HABITABLE);
-        }
-        else if(requirement.equals(colonyExtremeWeather))
-        {
-            return market.hasCondition(Conditions.EXTREME_WEATHER) || market.hasCondition("US_storm");
-        }
-        else if(requirement.equals(colonyNormalClimate))
-        {
-            return !market.hasCondition(Conditions.MILD_CLIMATE) && !market.hasCondition(Conditions.EXTREME_WEATHER) && !market.hasCondition("US_storm");
-        }
-        else if(requirement.equals(colonyAtmosphereToxic))
-        {
-            return market.hasCondition(Conditions.TOXIC_ATMOSPHERE);
-        }
-        else if(requirement.equals(colonyIrradiated))
-        {
-            return market.hasCondition(Conditions.IRRADIATED);
-        }
-        else if(requirement.equals(colonyHasAtmosphere))
-        {
-            return !market.hasCondition(Conditions.NO_ATMOSPHERE);
-        }
-        else if(requirement.equals(colonyAtmosphereSuboptimalDensity))
-        {
-            return market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE);
-        }
-        else if(requirement.equals(worldTypeSupportsFarmlandImprovement))
-        {
-            return getMaxFarmlandForMarket(market) > getCurrentFarmlandForMarket(market);
-        }
-        else if(requirement.equals(worldTypeSupportsOrganicsImprovement))
-        {
-            return getMaxOrganicsForMarket(market) > getCurrentOrganicsForMarket(market);
-        }
-        else if(requirement.equals(worldTypeSupportsVolatilesImprovement))
-        {
-            return getMaxVolatilesForMarket(market) > getCurrentVolatilesForMarket(market);
-        }
-        else if(requirement.equals(worldTypeAllowsTerraforming))
-        {
-            if(planetType.equals(starPlanetID) || planetType.equals(gasGiantPlanetID) || planetType.equals(volcanicPlanetID) || planetType.equals(unknownPlanetID))
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
-        }
-        else if(requirement.equals(worldTypeAllowsMildClimate) || requirement.equals(worldTypeAllowsHumanHabitability))
-        {
-            if(planetType.equals(junglePlanetID) || planetType.equals(desertPlanetID) || planetType.equals(terranPlanetID) || planetType.equals(waterPlanetID) || planetType.equals(tundraPlanetID))
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else if(requirement.equals(colonyHasAtLeast100kInhabitants))
-        {
-            if(market.getSize() >= 5)
-            {
-                return true;
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else if(requirement.equals(colonyHasOrbitalWorksWPristineNanoforge))
-        {
-            if(market.hasIndustry(Industries.ORBITALWORKS) && market.getIndustry(Industries.ORBITALWORKS).isFunctional())
-            {
-                for (SpecialItemData data : market.getIndustry(Industries.ORBITALWORKS).getVisibleInstalledItems()) {
-                    if (data.getId().equals(Items.PRISTINE_NANOFORGE) || data.getId().equals("uaf_dimen_nanoforge")) {
-                        return true;
-                    }
+            for (SpecialItemData specialItemData : industry.getVisibleInstalledItems()) {
+                if (itemID.equals(specialItemData.getId())) {
+                    return true;
                 }
             }
             return false;
         }
-        else if(requirement.contains("Fleet cargo contains at least"))
-        {
-            String[] words = requirement.split(" ");
-            CargoAPI playerCargo = Global.getSector().getPlayerFleet().getCargo();
-            return playerCargo.getCommodityQuantity(BoggledCommodities.domainArtifacts) >= Integer.parseInt(words[5]);
+    }
+
+    public static class MarketHasWaterPresent extends TerraformingRequirement {
+        int minWaterLevel;
+        int maxWaterLevel;
+        MarketHasWaterPresent(boolean invert, int minWaterLevel, int maxWaterLevel) {
+            super(invert);
+            this.minWaterLevel = minWaterLevel;
+            this.maxWaterLevel = maxWaterLevel;
         }
-        else if(requirement.equals(boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost) + " story points available to spend"))
-        {
-            MutableCharacterStatsAPI charStats = Global.getSector().getPlayerStats();
-            return charStats.getStoryPoints() >= boggledTools.getIntSetting(BoggledSettings.domainTechCraftingStoryPointCost);
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            int waterLevel = getPlanetWaterLevel(market);
+            return minWaterLevel <= waterLevel && waterLevel <= maxWaterLevel;
         }
-//        else if(requirement.equals(aotd_TypeChangeResearchRequirement))
-//        {
-//            return AoTDMainResearchManager.getInstance().isResearchedForPlayer(aotd_TypeChangeResearchRequirementID);
-//        }
-//        else if (requirement.equals(aotd_ResourceImprovementResearchRequirement))
-//        {
-//            return AoTDMainResearchManager.getInstance().isResearchedForPlayer(aotd_ResourceImprovementResearchRequirementID);
-//        }
-//        else if (requirement.equals(aotd_ConditionImprovementResearchRequirement))
-//        {
-//            return AoTDMainResearchManager.getInstance().isResearchedForPlayer(aotd_ConditionImprovementResearchRequirementID);
-//        }
+    }
+
+
+    public static class MarketIsAtLeastSize extends TerraformingRequirement {
+        int colonySize;
+        MarketIsAtLeastSize(boolean invert, int colonySize) {
+            super(invert);
+            this.colonySize = colonySize;
+        }
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            return market.getSize() >= colonySize;
+        }
+    }
+
+    public static class FleetCargoContainsAtLeast extends TerraformingRequirement {
+        String cargoID;
+        int quantity;
+        FleetCargoContainsAtLeast(boolean invert, String cargoID, int quantity) {
+            super(invert);
+            this.cargoID = cargoID;
+            this.quantity = quantity;
+        }
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            return Global.getSector().getPlayerFleet().getCargo().getCommodityQuantity(cargoID) >= quantity;
+        }
+    }
+
+    public static class PlayerHasStoryPointsAtLeast extends TerraformingRequirement {
+        int quantity;
+        PlayerHasStoryPointsAtLeast(boolean invert, int quantity) {
+            super(invert);
+            this.quantity = quantity;
+        }
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            return Global.getSector().getPlayerStats().getStoryPoints() >= quantity;
+        }
+    }
+
+    public static class WorldTypeSupportsResourceImprovement extends TerraformingRequirement {
+        String resourceID;
+        WorldTypeSupportsResourceImprovement(boolean invert, String resourceID) {
+            super(invert);
+            this.resourceID = resourceID;
+        }
+
+        @Override
+        protected boolean checkRequirementImpl(MarketAPI market) {
+            switch (resourceID) {
+                case BoggledResources.farmlandResourceID:
+                    return getMaxFarmlandForMarket(market) > getCurrentFarmlandForMarket(market);
+                case BoggledResources.organicsResourceID:
+                    return getMaxOrganicsForMarket(market) > getCurrentOrganicsForMarket(market);
+                case BoggledResources.volatilesResourceID:
+                    return getMaxVolatilesForMarket(market) > getCurrentVolatilesForMarket(market);
+            }
+            return false;
+        }
+    }
+
+    public static boolean requirementMet2(MarketAPI market, TerraformingRequirements terraformingRequirements) {
+        return terraformingRequirements.checkRequirement(market);
+    }
+
+    public static boolean requirementMet(MarketAPI market, String requirement)
+    {
+        if(requirement.equals("You should never see this text. If you do, tell Boggled about it on the forums."))
+        {
+            return false;
+        }
         else
         {
             return false;
         }
     }
 
-    public static boolean projectRequirementsMet(MarketAPI market, String project)
-    {
-        String[] requirements = getProjectRequirementsStrings(project);
-        for (String requirement : requirements) {
-            if (!requirementMet(market, requirement)) {
-                return false;
+    public static boolean projectRequirementsMet(MarketAPI market, TerraformingProject terraformingProject) {
+        if (terraformingProject != null) {
+            for (TerraformingRequirements requirements : terraformingProject.projectRequirements) {
+                if (!requirements.checkRequirement(market)) {
+                    return false;
+                }
             }
         }
-
-        // Returns true if no requirement was failed above
         return true;
+    }
+
+    public static boolean projectRequirementsMet(MarketAPI market, String project)
+    {
+        TerraformingProject terraformingProject = getProject(project);
+        return projectRequirementsMet(market, terraformingProject);
     }
 
     public static Boolean printProjectRequirementsReportIfStalled(MarketAPI market, String project, TextPanelAPI text)
     {
-        Color highlight = Misc.getHighlightColor();
+//        Color highlight = Misc.getHighlightColor();
         Color good = Misc.getPositiveHighlightColor();
         Color bad = Misc.getNegativeHighlightColor();
 
@@ -2755,18 +3056,21 @@ public class boggledTools
         {
             // Print requirements, and if not met, print terraforming is stalled
             text.addPara("Project Requirements:");
-            String[] requirements = boggledTools.getProjectRequirementsStrings(project);
-            boolean foundUnmetRequirement = false;
-            for (String requirement : requirements) {
-                if (boggledTools.requirementMet(market, requirement)) {
-                    text.addPara("      - %s", good, requirement);
-                } else {
-                    text.addPara("      - %s", bad, requirement);
-                    foundUnmetRequirement = true;
-                }
-            }
 
-            return foundUnmetRequirement;
+            TerraformingProject terraformingProject = getProject(project);
+            if (terraformingProject != null) {
+                boolean foundUnmetRequirement = false;
+                for (TerraformingRequirements terraformingRequirements : terraformingProject.projectRequirements) {
+                    if (terraformingRequirements.checkRequirement(market)) {
+                        text.addPara("      - %s", good, terraformingRequirements.tooltip);
+                    }
+                    else {
+                        text.addPara("      - %s", bad, terraformingRequirements.tooltip);
+                        foundUnmetRequirement = true;
+                    }
+                }
+                return foundUnmetRequirement;
+            }
         }
 
         return false;
@@ -2775,122 +3079,14 @@ public class boggledTools
     public static void printProjectResults(MarketAPI market, String project, TextPanelAPI text)
     {
         Color highlight = Misc.getHighlightColor();
-        Color good = Misc.getPositiveHighlightColor();
-        Color bad = Misc.getNegativeHighlightColor();
 
-        switch (project) {
-            case aridTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
+        TerraformingProject terraformingProject = getProject(project);
 
-                text.addPara("      - Arid world starting resources:");
-                text.addPara("          - Adequate farmland, common organics, no volatiles");
-                text.addPara("      - Arid world maximum resources:");
-                text.addPara("          - Bountiful farmland, abundant organics, trace volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case frozenTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Frozen world starting resources:");
-                text.addPara("          - No farmland, no organics, abundant volatiles");
-                text.addPara("      - Frozen world maximum resources:");
-                text.addPara("          - No farmland, no organics, plentiful volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case jungleTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Jungle world starting resources:");
-                text.addPara("          - Adequate farmland, common organics, no volatiles");
-                text.addPara("      - Jungle world maximum resources:");
-                text.addPara("          - Bountiful farmland, plentiful organics, no volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case terranTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Terran world starting resources:");
-                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    text.addPara("          - Adequate farmland, trace organics, trace volatiles");
-                } else {
-                    text.addPara("          - Adequate farmland, trace organics, no volatiles");
-                }
-                text.addPara("      - Terran world maximum resources:");
-                text.addPara("          - Bountiful farmland, plentiful organics, trace volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case waterTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Water world starting resources:");
-                text.addPara("          - No organics, no volatiles");
-                text.addPara("      - Water world maximum resources:");
-                text.addPara("          - Plentiful organics, plentiful volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case tundraTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Tundra world starting resources:");
-                if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    text.addPara("          - Adequate farmland, trace organics, trace volatiles");
-                } else {
-                    text.addPara("          - Adequate farmland, trace organics, no volatiles");
-                }
-                text.addPara("      - Tundra world maximum resources:");
-                text.addPara("          - Bountiful farmland, trace organics, plentiful volatiles");
-                text.addPara("      - Ore deposits are unaffected");
-                break;
-            case farmlandResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Farming yield improved by one");
-                break;
-            case organicsResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Organics yield improved by one");
-                break;
-            case volatilesResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Volatiles yield improved by one");
-                break;
-            case extremeWeatherConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Extreme weather patterns remediated");
-                break;
-            case mildClimateConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Climate made mild");
-                break;
-            case habitableConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Atmosphere made human-breathable");
-                break;
-            case atmosphereDensityConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Atmosphere with Earth-like density created");
-                break;
-            case toxicAtmosphereConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Atmospheric toxicity remediated");
-                break;
-            case irradiatedConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Radiation remediated");
-                break;
-            case removeAtmosphereConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
-
-                text.addPara("      - Atmosphere removed");
-                break;
+        if (terraformingProject != null) {
+            text.addPara("Prospective project: %s", highlight, terraformingProject.getProjectTooltip());
+            for (String result : terraformingProject.projectResults) {
+                text.addPara(result);
+            }
         }
     }
 
@@ -2915,34 +3111,6 @@ public class boggledTools
         }
     }
 
-    public static boolean marketHasAtmosphereProcessor(MarketAPI market)
-    {
-        return market.getIndustry(BoggledIndustries.atmosphereProcessorIndustryID) != null && market.getIndustry(BoggledIndustries.atmosphereProcessorIndustryID).isFunctional() && market.hasIndustry(BoggledIndustries.atmosphereProcessorIndustryID);
-    }
-
-    public static boolean marketHasGenelab(MarketAPI market)
-    {
-        return market.getIndustry(BoggledIndustries.genelabIndustryID) != null && market.getIndustry(BoggledIndustries.genelabIndustryID).isFunctional() && market.hasIndustry(BoggledIndustries.genelabIndustryID);
-    }
-
-    public static boolean marketHasStellarReflectorArray(MarketAPI market)
-    {
-        // Should be functionally the same as the commented out code, unless the player disables autoplacement in the settings file.
-        // Then this will allow terraforming on planets that start with reflectors without having to build the structure on them.
-        return market.hasCondition(Conditions.SOLAR_ARRAY);
-
-        /*
-        if(market.getIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY") != null && market.getIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY").isFunctional() && market.hasIndustry("BOGGLED_STELLAR_REFLECTOR_ARRAY"))
-        {
-            return true;
-        }
-        else
-        {
-            return false;
-        }
-        */
-    }
-
     public static boolean marketHasAtmoProblem(MarketAPI market)
     {
         if(!market.hasCondition(Conditions.MILD_CLIMATE) || !market.hasCondition(Conditions.HABITABLE) || market.hasCondition(Conditions.NO_ATMOSPHERE) || market.hasCondition(Conditions.THIN_ATMOSPHERE) || market.hasCondition(Conditions.DENSE_ATMOSPHERE) || market.hasCondition(Conditions.TOXIC_ATMOSPHERE) || market.hasCondition("US_storm"))
@@ -2955,53 +3123,6 @@ public class boggledTools
         }
     }
 
-    public static boolean marketIsIrradiated(MarketAPI market)
-    {
-        return market.hasCondition(Conditions.IRRADIATED);
-    }
-
-    public static int waterLevelNeededForProject(String project)
-    {
-        if(project.contains("TypeChange"))
-        {
-            if(project.equals(waterTypeChangeProjectID) || project.equals(frozenTypeChangeProjectID))
-            {
-                return 2;
-            }
-            else
-            {
-                // Need to adjust this if I end up allowing terraforming to US planet types or barren/toxic.
-                // Assumes project type is Terran, jungle, arid or tundra.
-                return 1;
-            }
-        }
-        else if(project.contains("ResourceImprovement"))
-        {
-            if(project.equals(farmlandResourceImprovementProjectID))
-            {
-                return 2;
-            }
-            else if(project.equals(organicsResourceImprovementProjectID) || project.equals(volatilesResourceImprovementProjectID))
-            {
-                return 0;
-            }
-        }
-        else if(project.contains("ConditionImprovement"))
-        {
-            if(project.equals(habitableConditionImprovementProjectID) || project.equals(mildClimateConditionImprovementProjectID) || project.equals(extremeWeatherConditionImprovementProjectID) || project.equals("noAtmosphereConditionImprovement") || project.equals("thinAtmosphereConditionImprovement"))
-            {
-                return 1;
-            }
-            else if(project.equals("denseAtmosphereConditionImprovement") || project.equals(toxicAtmosphereConditionImprovementProjectID))
-            {
-                return 0;
-            }
-        }
-
-        // Should never be reached unless there's a bug present and/or bad value passed in
-        return 0;
-    }
-
     public static String getTooltipProjectName(String currentProject)
     {
         if(currentProject == null || currentProject.equals(noneProjectID))
@@ -3009,13 +3130,11 @@ public class boggledTools
             return noneProjectID;
         }
 
-        String tooltip = projectTooltip.get(currentProject);
-        if(tooltip != null)
-        {
-            return tooltip;
-        }
-        else
-        {
+        reinitialiseInfo();
+        TerraformingProject terraformingProject = getProject(currentProject);
+        if (terraformingProject != null) {
+            return terraformingProject.projectTooltip;
+        } else {
             return "ERROR";
         }
     }

--- a/src/data/campaign/econ/boggledTools.java
+++ b/src/data/campaign/econ/boggledTools.java
@@ -1671,91 +1671,71 @@ public class boggledTools
             orbit = station.getOrbit();
         }
 
+        SectorEntityToken targetTokenToDelete = null;
         switch (stationType) {
             case "astropolis": {
-                SectorEntityToken targetTokenToDelete = null;
-
+                String smallTag = null;
+                String mediumTag = null;
+                String largeTag = null;
                 switch (stationGreekLetter) {
                     case "alpha": {
-                        for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisAlphaLarge))) {
-                                targetTokenToDelete = entity;
-                                break;
-                            }
-                        }
+                        smallTag = BoggledTags.lightsOverlayAstropolisAlphaSmall;
+                        mediumTag = BoggledTags.lightsOverlayAstropolisAlphaMedium;
+                        largeTag = BoggledTags.lightsOverlayAstropolisAlphaLarge;
 
-                        if (targetTokenToDelete != null) {
-                            system.removeEntity(targetTokenToDelete);
-                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                        }
                         break;
                     }
                     case "beta": {
-                        for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisBetaLarge))) {
-                                targetTokenToDelete = entity;
-                                break;
-                            }
-                        }
-
-                        if (targetTokenToDelete != null) {
-                            system.removeEntity(targetTokenToDelete);
-                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                        }
+                        smallTag = BoggledTags.lightsOverlayAstropolisBetaSmall;
+                        mediumTag = BoggledTags.lightsOverlayAstropolisBetaMedium;
+                        largeTag = BoggledTags.lightsOverlayAstropolisBetaLarge;
                         break;
                     }
                     case "gamma": {
-                        for (SectorEntityToken entity : system.getAllEntities()) {
-                            if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaSmall) || entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaMedium) || entity.hasTag(BoggledTags.lightsOverlayAstropolisGammaLarge))) {
-                                targetTokenToDelete = entity;
-                                break;
-                            }
-                        }
-
-                        if (targetTokenToDelete != null) {
-                            system.removeEntity(targetTokenToDelete);
-                            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                        }
+                        smallTag = BoggledTags.lightsOverlayAstropolisGammaSmall;
+                        mediumTag = BoggledTags.lightsOverlayAstropolisGammaMedium;
+                        largeTag = BoggledTags.lightsOverlayAstropolisGammaLarge;
                         break;
                     }
+                }
+
+                if (smallTag != null) {
+                    for (SectorEntityToken entity : system.getAllEntities()) {
+                        if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && entity.getCircularOrbitAngle() == station.getCircularOrbitAngle() && (entity.hasTag(smallTag) || entity.hasTag(mediumTag) || entity.hasTag(largeTag))) {
+                            targetTokenToDelete = entity;
+                            break;
+                        }
+                    }
+
                 }
                 break;
             }
             case "mining": {
-                SectorEntityToken targetTokenToDelete = null;
-
                 for (SectorEntityToken entity : system.getAllEntities()) {
                     if (entity.hasTag(BoggledTags.lightsOverlayMiningSmall) || entity.hasTag(BoggledTags.lightsOverlayMiningMedium)) {
                         targetTokenToDelete = entity;
                         break;
                     }
                 }
-
-                if (targetTokenToDelete != null) {
-                    system.removeEntity(targetTokenToDelete);
-                    deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                }
                 break;
             }
             case "siphon": {
-                SectorEntityToken targetTokenToDelete = null;
-
                 for (SectorEntityToken entity : system.getAllEntities()) {
                     if (entity.getOrbitFocus() != null && entity.getOrbitFocus().equals(station.getOrbitFocus()) && (entity.hasTag(BoggledTags.lightsOverlaySiphonSmall) || entity.hasTag(BoggledTags.lightsOverlaySiphonMedium))) {
                         targetTokenToDelete = entity;
                         break;
                     }
                 }
-
-                if (targetTokenToDelete != null) {
-                    system.removeEntity(targetTokenToDelete);
-                    deleteOldLightsOverlay(station, stationType, stationGreekLetter);
-                }
                 break;
             }
             default:
                 //Do nothing because the station type is unrecognized
                 return;
+        }
+
+        if (targetTokenToDelete != null) {
+            system.removeEntity(targetTokenToDelete);
+            deleteOldLightsOverlay(station, stationType, stationGreekLetter);
         }
     }
 
@@ -2444,7 +2424,7 @@ public class boggledTools
                 break;
         }
 
-        market.getPlanetEntity().changeType(newPlanetType, null);
+        market.getPlanetEntity().changeType(newPlanetType.replace("TypeChange",""), null);
 
         Pair<ArrayList<String>, ArrayList<String>> conditionsAddedRemoved = planetTypeChangeConditions.get(newPlanetType);
         if (conditionsAddedRemoved != null) {

--- a/src/data/campaign/econ/boggledTools.java
+++ b/src/data/campaign/econ/boggledTools.java
@@ -111,7 +111,7 @@ public class boggledTools
     private static final String atmosphereDensityConditionImprovementProjectID = "atmosphereDensityConditionImprovement";
     private static final String toxicAtmosphereConditionImprovementProjectID = "toxicAtmosphereConditionImprovement";
     private static final String irradiatedConditionImprovementProjectID = "irradiatedConditionImprovement";
-    private static final String radiationConditionImprovementProjectID = "radiationConditionImprovement";
+    private static final String radiationConditionImprovementProjectID = "irradiatedConditionImprovement";
     private static final String removeAtmosphereConditionImprovementProjectID = "removeAtmosphereConditionImprovement";
 
     private static final String aotd_TypeChangeResearchRequirement = "Researched: Terraforming Templates";
@@ -501,7 +501,7 @@ public class boggledTools
         if (!playerMarketInSystem(playerFleet)) {
             return null;
         } else {
-            ArrayList<SectorEntityToken> allPlayerMarketsInSystem = new ArrayList<SectorEntityToken>();
+            ArrayList<SectorEntityToken> allPlayerMarketsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity.getMarket() != null && entity.getMarket().isPlayerOwned()) {
@@ -536,7 +536,7 @@ public class boggledTools
         if (!gasGiantInSystem(playerFleet)) {
             return null;
         } else {
-            ArrayList<SectorEntityToken> allGasGiantsInSystem = new ArrayList<SectorEntityToken>();
+            ArrayList<SectorEntityToken> allGasGiantsInSystem = new ArrayList<>();
 
             for (SectorEntityToken planet : playerFleet.getStarSystem().getAllEntities()) {
                 if (planet instanceof PlanetAPI && ((PlanetAPI) planet).isGasGiant()) {
@@ -571,7 +571,7 @@ public class boggledTools
         if (!colonizableStationInSystem(playerFleet)) {
             return null;
         } else {
-            ArrayList<SectorEntityToken> allColonizableStationsInSystem = new ArrayList<SectorEntityToken>();
+            ArrayList<SectorEntityToken> allColonizableStationsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity.hasTag("station") && entity.getMarket() != null && entity.getMarket().hasCondition(Conditions.ABANDONED_STATION)) {
@@ -606,7 +606,7 @@ public class boggledTools
         if (!stationInSystem(playerFleet)) {
             return null;
         } else {
-            ArrayList<SectorEntityToken> allStationsInSystem = new ArrayList<SectorEntityToken>();
+            ArrayList<SectorEntityToken> allStationsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity.hasTag("station")) {
@@ -628,7 +628,7 @@ public class boggledTools
     }
 
     public static ArrayList<String> getListOfFactionsWithMarketInSystem(StarSystemAPI system) {
-        ArrayList<String> factionsWithMarketInSystem = new ArrayList<String>();
+        ArrayList<String> factionsWithMarketInSystem = new ArrayList<>();
 
         for (MarketAPI market : Global.getSector().getEconomy().getMarkets(system)) {
             if (!factionsWithMarketInSystem.contains(market.getFactionId())) {
@@ -640,7 +640,7 @@ public class boggledTools
     }
 
     public static ArrayList<Integer> getCompanionListOfTotalMarketPopulation(StarSystemAPI system, ArrayList<String> factions) {
-        ArrayList<Integer> totalFactionMarketSize = new ArrayList<Integer>();
+        ArrayList<Integer> totalFactionMarketSize = new ArrayList<>();
         int buffer = 0;
 
         for (String faction : factions) {
@@ -675,7 +675,7 @@ public class boggledTools
         if (!planetInSystem(playerFleet)) {
             return null;
         } else {
-            ArrayList<SectorEntityToken> allPlanetsInSystem = new ArrayList<SectorEntityToken>();
+            ArrayList<SectorEntityToken> allPlanetsInSystem = new ArrayList<>();
 
             for (SectorEntityToken entity : playerFleet.getStarSystem().getAllEntities()) {
                 if (entity instanceof PlanetAPI && !getPlanetType(((PlanetAPI) entity)).equals("star")) {
@@ -2413,7 +2413,7 @@ public class boggledTools
     {
         PlanetAPI planet = null;
         String planetType = "";
-        Integer planetWaterLevel = 0;
+        int planetWaterLevel = 0;
 
         if(!boggledTools.marketIsStation(market))
         {
@@ -2664,14 +2664,14 @@ public class boggledTools
         if(project != null && !project.equals("None"))
         {
             // Print requirements, and if not met, print terraforming is stalled
-            text.addPara("Project Requirements:", highlight, new String[]{""});
+            text.addPara("Project Requirements:");
             String[] requirements = boggledTools.getProjectRequirementsStrings(project);
-            Boolean foundUnmetRequirement = false;
+            boolean foundUnmetRequirement = false;
             for (String requirement : requirements) {
                 if (boggledTools.requirementMet(market, requirement)) {
-                    text.addPara("      - %s", good, new String[]{requirement + ""});
+                    text.addPara("      - %s", good, requirement);
                 } else {
-                    text.addPara("      - %s", bad, new String[]{requirement + ""});
+                    text.addPara("      - %s", bad, requirement);
                     foundUnmetRequirement = true;
                 }
             }
@@ -2688,119 +2688,118 @@ public class boggledTools
         Color good = Misc.getPositiveHighlightColor();
         Color bad = Misc.getNegativeHighlightColor();
 
-
         switch (project) {
             case aridTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Arid world starting resources:", highlight, new String[]{""});
-                text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
-                text.addPara("      - Arid world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - Bountiful farmland, abundant organics, trace volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Arid world starting resources:");
+                text.addPara("          - Adequate farmland, common organics, no volatiles");
+                text.addPara("      - Arid world maximum resources:");
+                text.addPara("          - Bountiful farmland, abundant organics, trace volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case frozenTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Frozen world starting resources:", highlight, new String[]{""});
-                text.addPara("          - No farmland, no organics, abundant volatiles", highlight, new String[]{""});
-                text.addPara("      - Frozen world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - No farmland, no organics, plentiful volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Frozen world starting resources:");
+                text.addPara("          - No farmland, no organics, abundant volatiles");
+                text.addPara("      - Frozen world maximum resources:");
+                text.addPara("          - No farmland, no organics, plentiful volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case jungleTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Jungle world starting resources:", highlight, new String[]{""});
-                text.addPara("          - Adequate farmland, common organics, no volatiles", highlight, new String[]{""});
-                text.addPara("      - Jungle world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - Bountiful farmland, plentiful organics, no volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Jungle world starting resources:");
+                text.addPara("          - Adequate farmland, common organics, no volatiles");
+                text.addPara("      - Jungle world maximum resources:");
+                text.addPara("          - Bountiful farmland, plentiful organics, no volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case terranTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Terran world starting resources:", highlight, new String[]{""});
+                text.addPara("      - Terran world starting resources:");
                 if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
+                    text.addPara("          - Adequate farmland, trace organics, trace volatiles");
                 } else {
-                    text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
+                    text.addPara("          - Adequate farmland, trace organics, no volatiles");
                 }
-                text.addPara("      - Terran world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - Bountiful farmland, plentiful organics, trace volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Terran world maximum resources:");
+                text.addPara("          - Bountiful farmland, plentiful organics, trace volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case waterTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Water world starting resources:", highlight, new String[]{""});
-                text.addPara("          - No organics, no volatiles", highlight, new String[]{""});
-                text.addPara("      - Water world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - Plentiful organics, plentiful volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Water world starting resources:");
+                text.addPara("          - No organics, no volatiles");
+                text.addPara("      - Water world maximum resources:");
+                text.addPara("          - Plentiful organics, plentiful volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case tundraTypeChangeProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Tundra world starting resources:", highlight, new String[]{""});
+                text.addPara("      - Tundra world starting resources:");
                 if (boggledTools.getBooleanSetting("boggledTerraformingTypeChangeAddVolatiles")) {
-                    text.addPara("          - Adequate farmland, trace organics, trace volatiles", highlight, new String[]{""});
+                    text.addPara("          - Adequate farmland, trace organics, trace volatiles");
                 } else {
-                    text.addPara("          - Adequate farmland, trace organics, no volatiles", highlight, new String[]{""});
+                    text.addPara("          - Adequate farmland, trace organics, no volatiles");
                 }
-                text.addPara("      - Tundra world maximum resources:", highlight, new String[]{""});
-                text.addPara("          - Bountiful farmland, trace organics, plentiful volatiles", highlight, new String[]{""});
-                text.addPara("      - Ore deposits are unaffected", highlight, new String[]{""});
+                text.addPara("      - Tundra world maximum resources:");
+                text.addPara("          - Bountiful farmland, trace organics, plentiful volatiles");
+                text.addPara("      - Ore deposits are unaffected");
                 break;
             case farmlandResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Farming yield improved by one", highlight, new String[]{""});
+                text.addPara("      - Farming yield improved by one");
                 break;
             case organicsResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Organics yield improved by one", highlight, new String[]{""});
+                text.addPara("      - Organics yield improved by one");
                 break;
             case volatilesResourceImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Volatiles yield improved by one", highlight, new String[]{""});
+                text.addPara("      - Volatiles yield improved by one");
                 break;
             case extremeWeatherConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Extreme weather patterns remediated", highlight, new String[]{""});
+                text.addPara("      - Extreme weather patterns remediated");
                 break;
             case mildClimateConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Climate made mild", highlight, new String[]{""});
+                text.addPara("      - Climate made mild");
                 break;
             case habitableConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Atmosphere made human-breathable", highlight, new String[]{""});
+                text.addPara("      - Atmosphere made human-breathable");
                 break;
             case atmosphereDensityConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Atmosphere with Earth-like density created", highlight, new String[]{""});
+                text.addPara("      - Atmosphere with Earth-like density created");
                 break;
             case toxicAtmosphereConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Atmospheric toxicity remediated", highlight, new String[]{""});
+                text.addPara("      - Atmospheric toxicity remediated");
                 break;
             case irradiatedConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Radiation remediated", highlight, new String[]{""});
+                text.addPara("      - Radiation remediated");
                 break;
             case removeAtmosphereConditionImprovementProjectID:
-                text.addPara("Prospective project: %s", highlight, new String[]{boggledTools.getTooltipProjectName(project)});
+                text.addPara("Prospective project: %s", highlight, boggledTools.getTooltipProjectName(project));
 
-                text.addPara("      - Atmosphere removed", highlight, new String[]{""});
+                text.addPara("      - Atmosphere removed");
                 break;
         }
     }

--- a/src/data/campaign/econ/conditions/Terraforming_Controller.java
+++ b/src/data/campaign/econ/conditions/Terraforming_Controller.java
@@ -223,7 +223,7 @@ public class Terraforming_Controller extends BaseHazardCondition
 
         double percentCompete = (daysCompleted / daysRequired) * 100;
         int returnValue = (int) percentCompete;
-        return Math.max(returnValue, 99);
+        return Math.min(returnValue, 99);
     }
 
     public void advance(float amount)
@@ -288,15 +288,15 @@ public class Terraforming_Controller extends BaseHazardCondition
                         currentProject = null;
                         daysCompleted = 0;
                         lastDayChecked = 0;
-                    }
 
-                    if (market.isPlayerOwned() || market.getFaction().isPlayerFaction())
-                    {
-                        MessageIntel intel = new MessageIntel("Terraforming on " + market.getName(), Misc.getBasePlayerColor());
-                        intel.addLine("    - Completed");
-                        intel.setIcon(Global.getSector().getPlayerFaction().getCrest());
-                        intel.setSound(BaseIntelPlugin.getSoundStandardUpdate());
-                        Global.getSector().getCampaignUI().addMessage(intel, CommMessageAPI.MessageClickAction.COLONY_INFO, market);
+                        if (market.isPlayerOwned() || market.getFaction().isPlayerFaction())
+                        {
+                            MessageIntel intel = new MessageIntel("Terraforming on " + market.getName(), Misc.getBasePlayerColor());
+                            intel.addLine("    - Completed");
+                            intel.setIcon(Global.getSector().getPlayerFaction().getCrest());
+                            intel.setSound(BaseIntelPlugin.getSoundStandardUpdate());
+                            Global.getSector().getCampaignUI().addMessage(intel, CommMessageAPI.MessageClickAction.COLONY_INFO, market);
+                        }
                     }
                 }
                 else

--- a/src/data/scripts/boggledCraftingPrintRequirements.java
+++ b/src/data/scripts/boggledCraftingPrintRequirements.java
@@ -6,6 +6,7 @@ import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.impl.campaign.rulecmd.BaseCommandPlugin;
 import com.fs.starfarer.api.util.Misc;
 import data.campaign.econ.boggledTools;
+
 import java.awt.*;
 import java.util.*;
 import java.util.List;
@@ -40,7 +41,6 @@ public class boggledCraftingPrintRequirements extends BaseCommandPlugin
         }
         else
         {
-            Color highlight = Misc.getHighlightColor();
             Color good = Misc.getPositiveHighlightColor();
             Color bad = Misc.getNegativeHighlightColor();
 
@@ -48,91 +48,92 @@ public class boggledCraftingPrintRequirements extends BaseCommandPlugin
 
             // Print crafting requirements
             String itemToCraftString = null;
+            String craftingProjectId = null;
             if(ruleId.contains("CorruptedNanoforge"))
             {
                 itemToCraftString = "a corrupted nanoforge";
+                craftingProjectId = boggledTools.craftCorruptedNanoforgeProjectID;
             }
             else if(ruleId.contains("PristineNanoforge"))
             {
                 itemToCraftString = "a pristine nanoforge";
+                craftingProjectId = boggledTools.craftPristineNanoforgeProjectID;
             }
             else if(ruleId.contains("SynchrotronCore"))
             {
                 itemToCraftString = "a synchrotron core";
+                craftingProjectId = boggledTools.craftSynchrotronProjectID;
             }
             else if(ruleId.contains("HypershuntTap"))
             {
                 itemToCraftString = "hypershunt tap";
+                craftingProjectId = boggledTools.craftHypershuntTapProjectID;
             }
             else if(ruleId.contains("CryoarithmeticEngine"))
             {
                 itemToCraftString = "a cryoarithmetic engine";
+                craftingProjectId = boggledTools.craftCryoarithmeticEngineProjectID;
             }
             else if(ruleId.contains("PlanetKillerDevice"))
             {
                 itemToCraftString = "a planet-killer device";
+                craftingProjectId = boggledTools.craftPlanetKillerDeviceProjectID;
             }
             else if(ruleId.contains("FusionLamp"))
             {
                 itemToCraftString = "a fusion lamp";
+                craftingProjectId = boggledTools.craftFusionLampProjectID;
             }
             else if(ruleId.contains("FullereneSpool"))
             {
                 itemToCraftString = "a fullerene spool";
+                craftingProjectId = boggledTools.craftFullereneSpoolProjectID;
             }
             else if(ruleId.contains("PlasmaDynamo"))
             {
                 itemToCraftString = "a plasma dynamo";
+                craftingProjectId = boggledTools.craftPlasmaDynamoProjectID;
             }
             else if(ruleId.contains("AutonomousMantleBore"))
             {
                 itemToCraftString = "an autonomous mantle bore";
+                craftingProjectId = boggledTools.craftAutonomousMantleBoreProjectID;
             }
             else if(ruleId.contains("SoilNanites"))
             {
                 itemToCraftString = "soil nanites";
+                craftingProjectId = boggledTools.craftSoilNanitesProjectID;
             }
             else if(ruleId.contains("CatalyticCore"))
             {
                 itemToCraftString = "a catalytic core";
+                craftingProjectId = boggledTools.craftCatalyticCoreProjectID;
             }
             else if(ruleId.contains("CombatDroneReplicator"))
             {
                 itemToCraftString = "a combat drone replicator";
+                craftingProjectId = boggledTools.craftCombatDroneReplicatorProjectID;
             }
             else if(ruleId.contains("BiofactoryEmbryo"))
             {
                 itemToCraftString = "a biofactory embryo";
+                craftingProjectId = boggledTools.craftBiofactoryEmbryoProjectID;
             }
             else if(ruleId.contains("DealmakerHolosuite"))
             {
                 itemToCraftString = "a dealmaker holosuite";
+                craftingProjectId = boggledTools.craftDealmakerHolosuiteProjectID;
             }
 
-            text.addPara("Requirements to craft " +  itemToCraftString + ":", highlight, new String[]{""});
-            String[] requirements = null;
-            if(ruleId.contains("CorruptedNanoforge") || ruleId.contains("CombatDroneReplicator") || ruleId.contains("DealmakerHolosuite"))
-            {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingEasy");
-            }
-            else if(ruleId.contains("PristineNanoforge") || ruleId.contains("HypershuntTap") || ruleId.contains("PlanetKillerDevice") || ruleId.contains("OrbitalFusionLamp"))
-            {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingHard");
-            }
-            else
-            {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingMedium");
-            }
-            int i;
-            for (i = 0; i < requirements.length; i++)
-            {
-                if(boggledTools.requirementMet(market, requirements[i]))
-                {
-                    text.addPara("      - %s", good, new String[]{requirements[i] + ""});
-                }
-                else
-                {
-                    text.addPara("      - %s", bad, new String[]{requirements[i] + ""});
+            text.addPara("Requirements to craft " +  itemToCraftString + ":");
+            boggledTools.TerraformingProject craftingProject = boggledTools.getCraftingProject(craftingProjectId);
+            if (craftingProject != null) {
+                for (boggledTools.TerraformingRequirements craftingRequirements : craftingProject.getProjectRequirements()) {
+                    if (craftingRequirements.checkRequirement(market)) {
+                        text.addPara("      - %s", good, craftingRequirements.getTooltip());
+                    } else {
+                        text.addPara("      - %s", bad, craftingRequirements.getTooltip());
+                    }
                 }
             }
         }

--- a/src/data/scripts/boggledCraftingRequirementsMet.java
+++ b/src/data/scripts/boggledCraftingRequirementsMet.java
@@ -6,6 +6,7 @@ import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.impl.campaign.rulecmd.BaseCommandPlugin;
 import com.fs.starfarer.api.util.Misc;
 import data.campaign.econ.boggledTools;
+
 import java.util.*;
 import java.util.List;
 import java.lang.String;
@@ -31,7 +32,6 @@ public class boggledCraftingRequirementsMet extends BaseCommandPlugin
         if(dialog == null) return false;
 
         this.entity = dialog.getInteractionTarget();
-        TextPanelAPI text = dialog.getTextPanel();
 
         if(this.entity.getMarket() == null)
         {
@@ -41,26 +41,74 @@ public class boggledCraftingRequirementsMet extends BaseCommandPlugin
         {
             MarketAPI market = this.entity.getMarket();
 
-            String[] requirements = null;
-            if(ruleId.contains("CorruptedNanoforge") || ruleId.contains("CombatDroneReplicator") || ruleId.contains("DealmakerHolosuite"))
+            String craftingProjectId = null;
+            if(ruleId.contains("CorruptedNanoforge"))
             {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingEasy");
+                craftingProjectId = boggledTools.craftCorruptedNanoforgeProjectID;
             }
-            else if(ruleId.contains("PristineNanoforge") || ruleId.contains("HypershuntTap") || ruleId.contains("PlanetKillerDevice") || ruleId.contains("OrbitalFusionLamp"))
+            else if(ruleId.contains("PristineNanoforge"))
             {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingHard");
+                craftingProjectId = boggledTools.craftPristineNanoforgeProjectID;
             }
-            else
+            else if(ruleId.contains("SynchrotronCore"))
             {
-                requirements = boggledTools.getProjectRequirementsStrings("boggledCraftingMedium");
+                craftingProjectId = boggledTools.craftSynchrotronProjectID;
+            }
+            else if(ruleId.contains("HypershuntTap"))
+            {
+                craftingProjectId = boggledTools.craftHypershuntTapProjectID;
+            }
+            else if(ruleId.contains("CryoarithmeticEngine"))
+            {
+                craftingProjectId = boggledTools.craftCryoarithmeticEngineProjectID;
+            }
+            else if(ruleId.contains("PlanetKillerDevice"))
+            {
+                craftingProjectId = boggledTools.craftPlanetKillerDeviceProjectID;
+            }
+            else if(ruleId.contains("FusionLamp"))
+            {
+                craftingProjectId = boggledTools.craftFusionLampProjectID;
+            }
+            else if(ruleId.contains("FullereneSpool"))
+            {
+                craftingProjectId = boggledTools.craftFullereneSpoolProjectID;
+            }
+            else if(ruleId.contains("PlasmaDynamo"))
+            {
+                craftingProjectId = boggledTools.craftPlasmaDynamoProjectID;
+            }
+            else if(ruleId.contains("AutonomousMantleBore"))
+            {
+                craftingProjectId = boggledTools.craftAutonomousMantleBoreProjectID;
+            }
+            else if(ruleId.contains("SoilNanites"))
+            {
+                craftingProjectId = boggledTools.craftSoilNanitesProjectID;
+            }
+            else if(ruleId.contains("CatalyticCore"))
+            {
+                craftingProjectId = boggledTools.craftCatalyticCoreProjectID;
+            }
+            else if(ruleId.contains("CombatDroneReplicator"))
+            {
+                craftingProjectId = boggledTools.craftCombatDroneReplicatorProjectID;
+            }
+            else if(ruleId.contains("BiofactoryEmbryo"))
+            {
+                craftingProjectId = boggledTools.craftBiofactoryEmbryoProjectID;
+            }
+            else if(ruleId.contains("DealmakerHolosuite"))
+            {
+                craftingProjectId = boggledTools.craftDealmakerHolosuiteProjectID;
             }
 
-            int i;
-            for (i = 0; i < requirements.length; i++)
-            {
-                if(!boggledTools.requirementMet(market, requirements[i]))
-                {
-                    return false;
+            boggledTools.TerraformingProject craftingProject = boggledTools.getCraftingProject(craftingProjectId);
+            if (craftingProject != null) {
+                for (boggledTools.TerraformingRequirements craftingRequirements : craftingProject.getProjectRequirements()) {
+                    if (!craftingRequirements.checkRequirement(market)) {
+                        return false;
+                    }
                 }
             }
         }

--- a/src/data/scripts/boggledTerraformingDialogPlugin.java
+++ b/src/data/scripts/boggledTerraformingDialogPlugin.java
@@ -22,54 +22,54 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
     private int pageNumber;
 
     private static final String aridTypeChangeYes = "boggledAridTypeChangeYes";
-    private static final String triggerAridTypeChange = "boggledTriggerAridTypeChange";
+    public static final String triggerAridTypeChange = "boggledTriggerAridTypeChange";
 
     private static final String frozenTypeChangeYes = "boggledFrozenTypeChangeYes";
-    private static final String triggerFrozenTypeChange = "boggledTriggerFrozenTypeChange";
+    public static final String triggerFrozenTypeChange = "boggledTriggerFrozenTypeChange";
 
     private static final String jungleTypeChangeYes = "boggledJungleTypeChangeYes";
-    private static final String triggerJungleTypeChange = "boggledTriggerJungleTypeChange";
+    public static final String triggerJungleTypeChange = "boggledTriggerJungleTypeChange";
 
     private static final String terranTypeChangeYes = "boggledTerranTypeChangeYes";
-    private static final String triggerTerranTypeChange = "boggledTriggerTerranTypeChange";
+    public static final String triggerTerranTypeChange = "boggledTriggerTerranTypeChange";
 
     private static final String tundraTypeChangeYes = "boggledTundraTypeChangeYes";
-    private static final String triggerTundraTypeChange = "boggledTriggerTundraTypeChange";
+    public static final String triggerTundraTypeChange = "boggledTriggerTundraTypeChange";
 
     private static final String waterTypeChangeYes = "boggledWaterTypeChangeYes";
-    private static final String triggerWaterTypeChange = "boggledTriggerWaterTypeChange";
+    public static final String triggerWaterTypeChange = "boggledTriggerWaterTypeChange";
 
     private static final String farmlandResourceImprovementYes = "boggledFarmlandResourceImprovementYes";
-    private static final String triggerFarmlandResourceImprovement = "boggledTriggerFarmlandResourceImprovement";
+    public static final String triggerFarmlandResourceImprovement = "boggledTriggerFarmlandResourceImprovement";
 
     private static final String organicsResourceImprovementYes = "boggledOrganicsResourceImprovementYes";
-    private static final String triggerOrganicsResourceImprovement = "boggledTriggerOrganicsResourceImprovement";
+    public static final String triggerOrganicsResourceImprovement = "boggledTriggerOrganicsResourceImprovement";
 
     private static final String volatilesResourceImprovementYes = "boggledVolatilesResourceImprovementYes";
-    private static final String triggerVolatilesResourceImprovement = "boggledTriggerVolatilesResourceImprovement";
+    public static final String triggerVolatilesResourceImprovement = "boggledTriggerVolatilesResourceImprovement";
 
     private static final String extremeWeatherConditionImprovementYes = "boggledExtremeWeatherConditionImprovementYes";
-    private static final String triggerExtremeWeatherConditionImprovement = "boggledTriggerExtremeWeatherConditionImprovement";
+    public static final String triggerExtremeWeatherConditionImprovement = "boggledTriggerExtremeWeatherConditionImprovement";
 
     private static final String mildClimateConditionImprovementYes = "boggledMildClimateConditionImprovementYes";
-    private static final String triggerMildClimateConditionImprovement = "boggledTriggerMildClimateConditionImprovement";
+    public static final String triggerMildClimateConditionImprovement = "boggledTriggerMildClimateConditionImprovement";
 
     private static final String habitableConditionImprovementYes = "boggledHabitableConditionImprovementYes";
-    private static final String triggerHabitableConditionImprovement = "boggledTriggerHabitableConditionImprovement";
+    public static final String triggerHabitableConditionImprovement = "boggledTriggerHabitableConditionImprovement";
 
     private static final String atmosphereDensityConditionImprovementYes = "boggledAtmosphereDensityConditionImprovementYes";
-    private static final String triggerAtmosphereDensityConditionImprovement = "boggledTriggerAtmosphereDensityConditionImprovement";
+    public static final String triggerAtmosphereDensityConditionImprovement = "boggledTriggerAtmosphereDensityConditionImprovement";
 
     private static final String toxicAtmosphereConditionImprovementYes = "boggledToxicAtmosphereConditionImprovementYes";
-    private static final String triggerToxicAtmosphereConditionImprovement = "boggledTriggerToxicAtmosphereConditionImprovement";
+    public static final String triggerToxicAtmosphereConditionImprovement = "boggledTriggerToxicAtmosphereConditionImprovement";
 
     private static final String irradiatedConditionImprovementYes = "boggledIrradiatedConditionImprovementYes";
-    private static final String triggerIrradiatedConditionImprovement = "boggledTriggerIrradiatedConditionImprovement";
+    public static final String triggerIrradiatedConditionImprovement = "boggledTriggerIrradiatedConditionImprovement";
 
     private static final String removeAtmosphereConditionImprovementYes = "boggledRemoveAtmosphereConditionImprovementYes";
-    private static final String triggerRemoveAtmosphereConditionImprovement = "boggledTriggerRemoveAtmosphereConditionImprovement";
+    public static final String triggerRemoveAtmosphereConditionImprovement = "boggledTriggerRemoveAtmosphereConditionImprovement";
 
-    private static final String triggerCancelCurrentProject = "boggledTriggerCancelCurrentProject";
+    public static final String triggerCancelCurrentProject = "boggledTriggerCancelCurrentProject";
 
     private HashMap<OptionId, String> initialiseOptionIdToProjectYesDialogue() {
         HashMap<OptionId, String> ret = new HashMap<>();

--- a/src/data/scripts/boggledTerraformingDialogPlugin.java
+++ b/src/data/scripts/boggledTerraformingDialogPlugin.java
@@ -246,82 +246,29 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
 
     private OptionId getOptionIdForInt(int i, boolean all)
     {
-        if(all)
-        {
-            if(i == 1)
-            {
-                return OptionId.COLONY_1_ALL;
+        if (all) {
+            switch (i) {
+                case 1: return OptionId.COLONY_1_ALL;
+                case 2: return OptionId.COLONY_2_ALL;
+                case 3: return OptionId.COLONY_3_ALL;
+                case 4: return OptionId.COLONY_4_ALL;
+                case 5: return OptionId.COLONY_5_ALL;
+                case 6: return OptionId.COLONY_6_ALL;
+                case 7: return OptionId.COLONY_7_ALL;
+                case 8: return OptionId.COLONY_8_ALL;
+                default: return null;
             }
-            else if(i == 2)
-            {
-                return OptionId.COLONY_2_ALL;
-            }
-            else if(i == 3)
-            {
-                return OptionId.COLONY_3_ALL;
-            }
-            else if(i == 4)
-            {
-                return OptionId.COLONY_4_ALL;
-            }
-            else if(i == 5)
-            {
-                return OptionId.COLONY_5_ALL;
-            }
-            else if(i == 6)
-            {
-                return OptionId.COLONY_6_ALL;
-            }
-            else if(i == 7)
-            {
-                return OptionId.COLONY_7_ALL;
-            }
-            else if(i == 8)
-            {
-                return OptionId.COLONY_8_ALL;
-            }
-            else
-            {
-                return null;
-            }
-        }
-        else
-        {
-            if(i == 1)
-            {
-                return OptionId.COLONY_1;
-            }
-            else if(i == 2)
-            {
-                return OptionId.COLONY_2;
-            }
-            else if(i == 3)
-            {
-                return OptionId.COLONY_3;
-            }
-            else if(i == 4)
-            {
-                return OptionId.COLONY_4;
-            }
-            else if(i == 5)
-            {
-                return OptionId.COLONY_5;
-            }
-            else if(i == 6)
-            {
-                return OptionId.COLONY_6;
-            }
-            else if(i == 7)
-            {
-                return OptionId.COLONY_7;
-            }
-            else if(i == 8)
-            {
-                return OptionId.COLONY_8;
-            }
-            else
-            {
-                return null;
+        } else {
+            switch (i) {
+                case 1: return OptionId.COLONY_1;
+                case 2: return OptionId.COLONY_2;
+                case 3: return OptionId.COLONY_3;
+                case 4: return OptionId.COLONY_4;
+                case 5: return OptionId.COLONY_5;
+                case 6: return OptionId.COLONY_6;
+                case 7: return OptionId.COLONY_7;
+                case 8: return OptionId.COLONY_8;
+                default: return null;
             }
         }
     }
@@ -474,20 +421,12 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
             pageNumber += 1;
         }
 
-        if(numMarkets <= 8)
+        for(int i = (pageNumber * 7); i < (pageNumber * 7) + 7 && i < numMarkets; i++)
         {
-            for(int i = 0; i < numMarkets; i++)
-            {
-                dialog.getOptionPanel().addOption(markets.get(i).getName(), getOptionIdForInt(i + 1, all));
-            }
+            dialog.getOptionPanel().addOption(markets.get(i).getName(), getOptionIdForInt((i - (pageNumber * 7)) + 1, all));
         }
-        else
+        if (numMarkets > 8)
         {
-            for(int i = (pageNumber * 7); i < (pageNumber * 7) + 7 && i < numMarkets; i++)
-            {
-                dialog.getOptionPanel().addOption(markets.get(i).getName(), getOptionIdForInt((i - (pageNumber * 7)) + 1, all));
-            }
-
             dialog.getOptionPanel().addOption("Next page", OptionId.ALL_COLONIES);
             dialog.getOptionPanel().setEnabled(OptionId.ALL_COLONIES, false);
             if( numMarkets - ((pageNumber + 1) * 7) > 0)

--- a/src/data/scripts/boggledTerraformingDialogPlugin.java
+++ b/src/data/scripts/boggledTerraformingDialogPlugin.java
@@ -6,20 +6,194 @@ import com.fs.starfarer.api.campaign.econ.MarketConditionAPI;
 import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.combat.EngagementResultAPI;
 import com.fs.starfarer.api.util.Misc;
+import com.fs.starfarer.api.util.Pair;
 import data.campaign.econ.boggledTools;
 import data.campaign.econ.conditions.Terraforming_Controller;
 
 import java.awt.*;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Map;
+import java.util.*;
+
+import static java.util.Arrays.asList;
 
 public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
 {
     protected InteractionDialogAPI dialog;
 
     private int pageNumber;
+
+    private static final String aridTypeChangeYes = "boggledAridTypeChangeYes";
+    private static final String triggerAridTypeChange = "boggledTriggerAridTypeChange";
+
+    private static final String frozenTypeChangeYes = "boggledFrozenTypeChangeYes";
+    private static final String triggerFrozenTypeChange = "boggledTriggerFrozenTypeChange";
+
+    private static final String jungleTypeChangeYes = "boggledJungleTypeChangeYes";
+    private static final String triggerJungleTypeChange = "boggledTriggerJungleTypeChange";
+
+    private static final String terranTypeChangeYes = "boggledTerranTypeChangeYes";
+    private static final String triggerTerranTypeChange = "boggledTriggerTerranTypeChange";
+
+    private static final String tundraTypeChangeYes = "boggledTundraTypeChangeYes";
+    private static final String triggerTundraTypeChange = "boggledTriggerTundraTypeChange";
+
+    private static final String waterTypeChangeYes = "boggledWaterTypeChangeYes";
+    private static final String triggerWaterTypeChange = "boggledTriggerWaterTypeChange";
+
+    private static final String farmlandResourceImprovementYes = "boggledFarmlandResourceImprovementYes";
+    private static final String triggerFarmlandResourceImprovement = "boggledTriggerFarmlandResourceImprovement";
+
+    private static final String organicsResourceImprovementYes = "boggledOrganicsResourceImprovementYes";
+    private static final String triggerOrganicsResourceImprovement = "boggledTriggerOrganicsResourceImprovement";
+
+    private static final String volatilesResourceImprovementYes = "boggledVolatilesResourceImprovementYes";
+    private static final String triggerVolatilesResourceImprovement = "boggledTriggerVolatilesResourceImprovement";
+
+    private static final String extremeWeatherConditionImprovementYes = "boggledExtremeWeatherConditionImprovementYes";
+    private static final String triggerExtremeWeatherConditionImprovement = "boggledTriggerExtremeWeatherConditionImprovement";
+
+    private static final String mildClimateConditionImprovementYes = "boggledMildClimateConditionImprovementYes";
+    private static final String triggerMildClimateConditionImprovement = "boggledTriggerMildClimateConditionImprovement";
+
+    private static final String habitableConditionImprovementYes = "boggledHabitableConditionImprovementYes";
+    private static final String triggerHabitableConditionImprovement = "boggledTriggerHabitableConditionImprovement";
+
+    private static final String atmosphereDensityConditionImprovementYes = "boggledAtmosphereDensityConditionImprovementYes";
+    private static final String triggerAtmosphereDensityConditionImprovement = "boggledTriggerAtmosphereDensityConditionImprovement";
+
+    private static final String toxicAtmosphereConditionImprovementYes = "boggledToxicAtmosphereConditionImprovementYes";
+    private static final String triggerToxicAtmosphereConditionImprovement = "boggledTriggerToxicAtmosphereConditionImprovement";
+
+    private static final String irradiatedConditionImprovementYes = "boggledIrradiatedConditionImprovementYes";
+    private static final String triggerIrradiatedConditionImprovement = "boggledTriggerIrradiatedConditionImprovement";
+
+    private static final String removeAtmosphereConditionImprovementYes = "boggledRemoveAtmosphereConditionImprovementYes";
+    private static final String triggerRemoveAtmosphereConditionImprovement = "boggledTriggerRemoveAtmosphereConditionImprovement";
+
+    private static final String triggerCancelCurrentProject = "boggledTriggerCancelCurrentProject";
+
+    private HashMap<OptionId, String> initialiseOptionIdToProjectYesDialogue() {
+        HashMap<OptionId, String> ret = new HashMap<>();
+
+        ret.put(OptionId.ARID_TYPE_CHANGE, aridTypeChangeYes);
+        ret.put(OptionId.FROZEN_TYPE_CHANGE, frozenTypeChangeYes);
+        ret.put(OptionId.JUNGLE_TYPE_CHANGE, jungleTypeChangeYes);
+        ret.put(OptionId.TERRAN_TYPE_CHANGE, terranTypeChangeYes);
+        ret.put(OptionId.TUNDRA_TYPE_CHANGE, tundraTypeChangeYes);
+        ret.put(OptionId.WATER_TYPE_CHANGE, waterTypeChangeYes);
+
+        ret.put(OptionId.FARMLAND_IMPROVEMENT, farmlandResourceImprovementYes);
+        ret.put(OptionId.ORGANICS_IMPROVEMENT, organicsResourceImprovementYes);
+        ret.put(OptionId.VOLATILES_IMPROVEMENT, volatilesResourceImprovementYes);
+
+        ret.put(OptionId.EXTREME_WEATHER_IMPROVEMENT, extremeWeatherConditionImprovementYes);
+        ret.put(OptionId.MILD_CLIMATE_IMPROVEMENT, mildClimateConditionImprovementYes);
+        ret.put(OptionId.HABITABLE_IMPROVEMENT, habitableConditionImprovementYes);
+        ret.put(OptionId.ATMOSPHERE_DENSITY_IMPROVEMENT, atmosphereDensityConditionImprovementYes);
+        ret.put(OptionId.TOXIC_ATMOSPHERE_IMPROVEMENT, toxicAtmosphereConditionImprovementYes);
+        ret.put(OptionId.IRRADIATED_IMPROVEMENT, irradiatedConditionImprovementYes);
+        ret.put(OptionId.REMOVE_ATMOSPHERE_IMPROVEMENT, removeAtmosphereConditionImprovementYes);
+
+        return ret;
+    }
+
+    private HashMap<OptionId, String> initialiseOptionIdToStartProjectDialogue() {
+        HashMap<OptionId, String> ret = new HashMap<>();
+
+        ret.put(OptionId.START_ARID_TYPE_CHANGE_PROJECT, triggerAridTypeChange);
+        ret.put(OptionId.START_FROZEN_TYPE_CHANGE_PROJECT, triggerFrozenTypeChange);
+        ret.put(OptionId.START_JUNGLE_TYPE_CHANGE_PROJECT, triggerJungleTypeChange);
+        ret.put(OptionId.START_TERRAN_TYPE_CHANGE_PROJECT, triggerTerranTypeChange);
+        ret.put(OptionId.START_TUNDRA_TYPE_CHANGE_PROJECT, triggerTundraTypeChange);
+        ret.put(OptionId.START_WATER_TYPE_CHANGE_PROJECT, triggerWaterTypeChange);
+
+        ret.put(OptionId.START_FARMLAND_IMPROVEMENT, triggerFarmlandResourceImprovement);
+        ret.put(OptionId.START_ORGANICS_IMPROVEMENT, triggerOrganicsResourceImprovement);
+        ret.put(OptionId.START_VOLATILES_IMPROVEMENT, triggerVolatilesResourceImprovement);
+
+        ret.put(OptionId.START_EXTREME_WEATHER_IMPROVEMENT, triggerExtremeWeatherConditionImprovement);
+        ret.put(OptionId.START_MILD_CLIMATE_IMPROVEMENT, triggerMildClimateConditionImprovement);
+        ret.put(OptionId.START_HABITABLE_IMPROVEMENT, triggerHabitableConditionImprovement);
+        ret.put(OptionId.START_ATMOSPHERE_DENSITY_IMPROVEMENT, triggerAtmosphereDensityConditionImprovement);
+        ret.put(OptionId.START_TOXIC_ATMOSPHERE_IMPROVEMENT, triggerToxicAtmosphereConditionImprovement);
+        ret.put(OptionId.START_IRRADIATED_IMPROVEMENT, triggerIrradiatedConditionImprovement);
+        ret.put(OptionId.START_REMOVE_ATMOSPHERE, triggerRemoveAtmosphereConditionImprovement);
+
+        ret.put(OptionId.START_CANCEL_PROJECT, triggerCancelCurrentProject);
+
+        return ret;
+    }
+
+    private HashMap<OptionId, Pair<OptionId, OptionId>> initialiseProjectOptionIdToStartProjectOptionId() {
+        HashMap<OptionId, Pair<OptionId, OptionId>> ret = new HashMap<>();
+
+        ret.put(OptionId.ARID_TYPE_CHANGE, new Pair<>(OptionId.START_ARID_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+        ret.put(OptionId.FROZEN_TYPE_CHANGE, new Pair<>(OptionId.START_FROZEN_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+        ret.put(OptionId.JUNGLE_TYPE_CHANGE, new Pair<>(OptionId.START_JUNGLE_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+        ret.put(OptionId.TERRAN_TYPE_CHANGE, new Pair<>(OptionId.START_TERRAN_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+        ret.put(OptionId.TUNDRA_TYPE_CHANGE, new Pair<>(OptionId.START_TUNDRA_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+        ret.put(OptionId.WATER_TYPE_CHANGE, new Pair<>(OptionId.START_WATER_TYPE_CHANGE_PROJECT, OptionId.TYPE_CHANGE_OPTIONS));
+
+        ret.put(OptionId.FARMLAND_IMPROVEMENT, new Pair<>(OptionId.START_FARMLAND_IMPROVEMENT, OptionId.RESOURCE_IMPROVEMENTS));
+        ret.put(OptionId.ORGANICS_IMPROVEMENT, new Pair<>(OptionId.START_ORGANICS_IMPROVEMENT, OptionId.RESOURCE_IMPROVEMENTS));
+        ret.put(OptionId.VOLATILES_IMPROVEMENT, new Pair<>(OptionId.START_VOLATILES_IMPROVEMENT, OptionId.RESOURCE_IMPROVEMENTS));
+
+        ret.put(OptionId.EXTREME_WEATHER_IMPROVEMENT, new Pair<>(OptionId.START_EXTREME_WEATHER_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.MILD_CLIMATE_IMPROVEMENT, new Pair<>(OptionId.START_MILD_CLIMATE_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.HABITABLE_IMPROVEMENT, new Pair<>(OptionId.START_HABITABLE_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.ATMOSPHERE_DENSITY_IMPROVEMENT, new Pair<>(OptionId.START_ATMOSPHERE_DENSITY_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.TOXIC_ATMOSPHERE_IMPROVEMENT, new Pair<>(OptionId.START_TOXIC_ATMOSPHERE_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.IRRADIATED_IMPROVEMENT, new Pair<>(OptionId.START_IRRADIATED_IMPROVEMENT, OptionId.CONDITION_IMPROVEMENTS));
+        ret.put(OptionId.REMOVE_ATMOSPHERE_IMPROVEMENT, new Pair<>(OptionId.START_REMOVE_ATMOSPHERE, OptionId.CONDITION_IMPROVEMENTS));
+
+        return ret;
+    }
+
+    private HashMap<OptionId, ArrayList<Pair<String, OptionId>>> initialiseTerraformingOptions() {
+        HashMap<OptionId, ArrayList<Pair<String, OptionId>>> ret = new HashMap<>();
+
+        ArrayList<Pair<String, OptionId>> typeChangeOptions = new ArrayList<>(asList(
+                new Pair<>("Consider terraforming $planet into an arid world", OptionId.ARID_TYPE_CHANGE),
+                new Pair<>("Consider terraforming $planet into a frozen world", OptionId.FROZEN_TYPE_CHANGE),
+                new Pair<>("Consider terraforming $planet into a jungle world", OptionId.JUNGLE_TYPE_CHANGE),
+                new Pair<>("Consider terraforming $planet into a Terran world", OptionId.TERRAN_TYPE_CHANGE),
+                new Pair<>("consider terraforming $planet into a tundra world", OptionId.TUNDRA_TYPE_CHANGE),
+                new Pair<>("Consider terraforming $planet into a water world", OptionId.WATER_TYPE_CHANGE)
+        ));
+
+        ArrayList<Pair<String, OptionId>> resourceImprovementOptions = new ArrayList<>(asList(
+                new Pair<>("Consider improving the farmland on $planet", OptionId.FARMLAND_IMPROVEMENT),
+                new Pair<>("Consider improving the organics on $planet", OptionId.ORGANICS_IMPROVEMENT),
+                new Pair<>("Consider improving the volatiles on $planet", OptionId.VOLATILES_IMPROVEMENT)
+        ));
+
+        ArrayList<Pair<String, OptionId>> conditionImprovementOptions = new ArrayList<>(asList(
+                new Pair<>("Consider making the weather patterns on $planet less extreme", OptionId.EXTREME_WEATHER_IMPROVEMENT),
+                new Pair<>("Consider making the weather patterns on $planet mild", OptionId.MILD_CLIMATE_IMPROVEMENT),
+                new Pair<>("Consider making the atmosphere on $planet human-breathable", OptionId.HABITABLE_IMPROVEMENT),
+                new Pair<>("Consider normalizing atmospheric density on $planet", OptionId.ATMOSPHERE_DENSITY_IMPROVEMENT),
+                new Pair<>("Consider remediating atmospheric toxicity on $planet", OptionId.TOXIC_ATMOSPHERE_IMPROVEMENT)
+        ));
+        if (boggledTools.getBooleanSetting("boggledTerraformingRemoveRadiationProjectEnabled"))
+        {
+            conditionImprovementOptions.add(new Pair<>("Consider remediating radiation on $planet", OptionId.IRRADIATED_IMPROVEMENT));
+        }
+        if (boggledTools.getBooleanSetting("boggledTerraformingRemoveAtmosphereProjectEnabled"))
+        {
+            conditionImprovementOptions.add(new Pair<>("Consider removing the atmosphere on $planet", OptionId.REMOVE_ATMOSPHERE_IMPROVEMENT));
+        }
+
+        ret.put(OptionId.TYPE_CHANGE_OPTIONS, typeChangeOptions);
+        ret.put(OptionId.RESOURCE_IMPROVEMENTS, resourceImprovementOptions);
+        ret.put(OptionId.CONDITION_IMPROVEMENTS, conditionImprovementOptions);
+
+        return ret;
+    }
+
+    private final HashMap<OptionId, String> projectOptionIdToProjectYesDialogue = initialiseOptionIdToProjectYesDialogue();
+    private final HashMap<OptionId, String> startProjectOptionIdToStartProjectDialogue = initialiseOptionIdToStartProjectDialogue();
+    private final HashMap<OptionId, Pair<OptionId, OptionId>> projectOptionIdToStartProjectOptionId = initialiseProjectOptionIdToStartProjectOptionId();
+
+    private final HashMap<OptionId, ArrayList<Pair<String, OptionId>>> terraformingOptions = initialiseTerraformingOptions();
 
     @Override
     public void init(InteractionDialogAPI dialog)
@@ -28,7 +202,7 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
         this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
     }
 
-    public OptionId getOptionIdForInt(int i, boolean all)
+    private OptionId getOptionIdForInt(int i, boolean all)
     {
         if(all)
         {
@@ -219,7 +393,7 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
         }
     }
 
-    class MarketComparator implements Comparator<MarketAPI>
+    static class MarketComparator implements Comparator<MarketAPI>
     {
         public int compare(MarketAPI market1, MarketAPI market2)
         {
@@ -231,6 +405,25 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
             else
                 return -1;
         }
+    }
+
+    private void typeChangeDialogueOption(boggledTerraformingPrintResultsAndRequirements printResultsAndRequirements, boggledTerraformingProjectRequirementsMet requirementsMet, OptionId projectOptionId)
+    {
+        String ruleId = projectOptionIdToProjectYesDialogue.get(projectOptionId);
+        Pair<OptionId, OptionId> optionId = projectOptionIdToStartProjectOptionId.get(projectOptionId);
+
+        // Print results and requirements for prospective project
+        printResultsAndRequirements.execute(ruleId, dialog, null, null);
+
+        dialog.getOptionPanel().addOption("Start project",optionId.one);
+
+        if (!requirementsMet.execute(ruleId, dialog, null, null))
+        {
+            dialog.getOptionPanel().setEnabled(optionId.one, false);
+        }
+
+        dialog.getOptionPanel().addOption("Back", optionId.two);
+        dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
     }
 
     @Override
@@ -375,349 +568,80 @@ public class boggledTerraformingDialogPlugin implements InteractionDialogPlugin
                     showColonySelectedOptionsAndLoadVisual(optionText, true, true);
                     break;
                 case VIEW_COLONY:
-                    printColonyConditions();
-                    showColonySelectedOptionsAndLoadVisual(optionText, false, false);
-                    break;
                 case VIEW_COLONY_ALL:
                     printColonyConditions();
-                    showColonySelectedOptionsAndLoadVisual(optionText, true, false);
+                    showColonySelectedOptionsAndLoadVisual(optionText, optionData.equals(OptionId.VIEW_COLONY_ALL), false);
                     break;
                 case CANCEL_PROJECT:
                     Color bad = Misc.getNegativeHighlightColor();
                     TextPanelAPI text = this.dialog.getTextPanel();
-                    text.addPara("%s", bad, new String[]{"Canceling the current project will result in all progress being lost!"});
+                    text.addPara("%s", bad, "Canceling the current project will result in all progress being lost!");
 
                     dialog.getOptionPanel().addOption("Cancel project", OptionId.START_CANCEL_PROJECT);
                     dialog.getOptionPanel().addOption("Back", OptionId.INIT);
                     dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
                     break;
-                case START_CANCEL_PROJECT:
-                    initiateProject.execute("boggledTriggerCancelCurrentProject", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
+
+
                 case TYPE_CHANGE_OPTIONS:
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into an arid world", OptionId.ARID_TYPE_CHANGE);
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into a frozen world", OptionId.FROZEN_TYPE_CHANGE);
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into a jungle world", OptionId.JUNGLE_TYPE_CHANGE);
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into a Terran world", OptionId.TERRAN_TYPE_CHANGE);
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into a tundra world", OptionId.TUNDRA_TYPE_CHANGE);
-                    dialog.getOptionPanel().addOption("Consider terraforming " + dialog.getInteractionTarget().getMarket().getName() + " into a water world", OptionId.WATER_TYPE_CHANGE);
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.COLONY_1);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case ARID_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledAridTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_ARID_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledAridTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_ARID_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_ARID_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerAridTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case FROZEN_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledFrozenTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_FROZEN_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledFrozenTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_FROZEN_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_FROZEN_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerFrozenTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case JUNGLE_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledJungleTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_JUNGLE_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledJungleTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_JUNGLE_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_JUNGLE_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerJungleTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case TERRAN_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledTerranTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_TERRAN_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledTerranTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_TERRAN_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_TERRAN_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerTerranTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case TUNDRA_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledTundraTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_TUNDRA_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledTundraTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_TUNDRA_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_TUNDRA_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerTundraTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case WATER_TYPE_CHANGE:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledWaterTypeChangeYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_WATER_TYPE_CHANGE_PROJECT);
-                    if(!requirementsMet.execute("boggledWaterTypeChangeYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_WATER_TYPE_CHANGE_PROJECT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.TYPE_CHANGE_OPTIONS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_WATER_TYPE_CHANGE_PROJECT:
-                    initiateProject.execute("boggledTriggerWaterTypeChange", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case RESOURCE_IMPROVEMENTS:
-                    dialog.getOptionPanel().addOption("Consider improving the farmland on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.FARMLAND_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider improving the organics on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.ORGANICS_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider improving the volatiles on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.VOLATILES_IMPROVEMENT);
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.COLONY_1);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case FARMLAND_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledFarmlandResourceImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_FARMLAND_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledFarmlandResourceImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_FARMLAND_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.RESOURCE_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_FARMLAND_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerFarmlandResourceImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case ORGANICS_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledOrganicsResourceImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_ORGANICS_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledOrganicsResourceImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_ORGANICS_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.RESOURCE_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_ORGANICS_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerOrganicsResourceImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
-                case VOLATILES_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledVolatilesResourceImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_VOLATILES_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledVolatilesResourceImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_VOLATILES_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.RESOURCE_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_VOLATILES_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerVolatilesResourceImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case CONDITION_IMPROVEMENTS:
-                    dialog.getOptionPanel().addOption("Consider making the weather patterns on " + dialog.getInteractionTarget().getMarket().getName() + " less extreme", OptionId.EXTREME_WEATHER_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider making the weather patterns on " + dialog.getInteractionTarget().getMarket().getName() + " mild", OptionId.MILD_CLIMATE_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider making the atmosphere on " + dialog.getInteractionTarget().getMarket().getName() + " human-breathable", OptionId.HABITABLE_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider normalizing atmospheric density on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.ATMOSPHERE_DENSITY_IMPROVEMENT);
-                    dialog.getOptionPanel().addOption("Consider remediating atmospheric toxicity on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.TOXIC_ATMOSPHERE_IMPROVEMENT);
-                    if(boggledTools.getBooleanSetting("boggledTerraformingRemoveRadiationProjectEnabled"))
+                    ArrayList<Pair<String, OptionId>> terraformingOption = terraformingOptions.get(optionData);
+                    for (Pair<String, OptionId> terraform : terraformingOption)
                     {
-                        dialog.getOptionPanel().addOption("Consider remediating radiation on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.IRRADIATED_IMPROVEMENT);
-                    }
-                    if(boggledTools.getBooleanSetting("boggledTerraformingRemoveAtmosphereProjectEnabled"))
-                    {
-                        dialog.getOptionPanel().addOption("Consider removing the atmosphere on " + dialog.getInteractionTarget().getMarket().getName(), OptionId.REMOVE_ATMOSPHERE_IMPROVEMENT);
+                        dialog.getOptionPanel().addOption(terraform.one.replace("$planet", dialog.getInteractionTarget().getMarket().getName()), terraform.two);
                     }
 
                     dialog.getOptionPanel().addOption("Back", OptionId.COLONY_1);
                     dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
                     break;
+
+                /*
+                Type changes from here
+                */
+                case ARID_TYPE_CHANGE:
+                case FROZEN_TYPE_CHANGE:
+                case JUNGLE_TYPE_CHANGE:
+                case TERRAN_TYPE_CHANGE:
+                case TUNDRA_TYPE_CHANGE:
+                case WATER_TYPE_CHANGE:
+
+                case FARMLAND_IMPROVEMENT:
+                case ORGANICS_IMPROVEMENT:
+                case VOLATILES_IMPROVEMENT:
+
                 case EXTREME_WEATHER_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledExtremeWeatherConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_EXTREME_WEATHER_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledExtremeWeatherConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_EXTREME_WEATHER_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_EXTREME_WEATHER_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerExtremeWeatherConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case MILD_CLIMATE_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledMildClimateConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_MILD_CLIMATE_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledMildClimateConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_MILD_CLIMATE_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_MILD_CLIMATE_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerMildClimateConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case HABITABLE_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledHabitableConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_HABITABLE_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledHabitableConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_HABITABLE_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_HABITABLE_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerHabitableConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case ATMOSPHERE_DENSITY_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledAtmosphereDensityConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_ATMOSPHERE_DENSITY_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledAtmosphereDensityConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_ATMOSPHERE_DENSITY_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_ATMOSPHERE_DENSITY_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerAtmosphereDensityConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case TOXIC_ATMOSPHERE_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledToxicAtmosphereConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_TOXIC_ATMOSPHERE_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledToxicAtmosphereConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_TOXIC_ATMOSPHERE_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_TOXIC_ATMOSPHERE_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerToxicAtmosphereConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case IRRADIATED_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledIrradiatedConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_IRRADIATED_IMPROVEMENT);
-                    if(!requirementsMet.execute("boggledIrradiatedConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_IRRADIATED_IMPROVEMENT, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
-                    break;
-                case START_IRRADIATED_IMPROVEMENT:
-                    initiateProject.execute("boggledTriggerIrradiatedConditionImprovement", dialog, null, null);
-                    this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
-                    break;
                 case REMOVE_ATMOSPHERE_IMPROVEMENT:
-                    // Print results and requirements for prospective project
-                    printResultsAndRequirements.execute("boggledRemoveAtmosphereConditionImprovementYes", dialog, null, null);
-
-                    // Add start project option and disable it if the requirements are not met
-                    dialog.getOptionPanel().addOption("Start project", OptionId.START_REMOVE_ATMOSPHERE);
-                    if(!requirementsMet.execute("boggledRemoveAtmosphereConditionImprovementYes", dialog, null, null))
-                    {
-                        dialog.getOptionPanel().setEnabled(OptionId.START_REMOVE_ATMOSPHERE, false);
-                    }
-
-                    dialog.getOptionPanel().addOption("Back", OptionId.CONDITION_IMPROVEMENTS);
-                    dialog.setOptionOnEscape("Exit", OptionId.DUMMY);
+                    typeChangeDialogueOption(printResultsAndRequirements, requirementsMet, (OptionId)optionData);
                     break;
+
+                case START_ARID_TYPE_CHANGE_PROJECT:
+                case START_FROZEN_TYPE_CHANGE_PROJECT:
+                case START_JUNGLE_TYPE_CHANGE_PROJECT:
+                case START_TERRAN_TYPE_CHANGE_PROJECT:
+                case START_TUNDRA_TYPE_CHANGE_PROJECT:
+                case START_WATER_TYPE_CHANGE_PROJECT:
+
+                case START_FARMLAND_IMPROVEMENT:
+                case START_ORGANICS_IMPROVEMENT:
+                case START_VOLATILES_IMPROVEMENT:
+
+                case START_EXTREME_WEATHER_IMPROVEMENT:
+                case START_MILD_CLIMATE_IMPROVEMENT:
+                case START_HABITABLE_IMPROVEMENT:
+                case START_ATMOSPHERE_DENSITY_IMPROVEMENT:
+                case START_TOXIC_ATMOSPHERE_IMPROVEMENT:
+                case START_IRRADIATED_IMPROVEMENT:
                 case START_REMOVE_ATMOSPHERE:
-                    initiateProject.execute("boggledTriggerRemoveAtmosphereConditionImprovement", dialog, null, null);
+
+                case START_CANCEL_PROJECT:
+                    String ruleId = startProjectOptionIdToStartProjectDialogue.get(optionData);
+                    initiateProject.execute(ruleId, dialog, null, null);
                     this.optionSelected(null, boggledTerraformingDialogPlugin.OptionId.INIT);
                     break;
             }

--- a/src/data/scripts/boggledTerraformingInitiateProject.java
+++ b/src/data/scripts/boggledTerraformingInitiateProject.java
@@ -5,6 +5,7 @@ import com.fs.starfarer.api.campaign.econ.MarketAPI;
 import com.fs.starfarer.api.campaign.rules.MemoryAPI;
 import com.fs.starfarer.api.impl.campaign.rulecmd.BaseCommandPlugin;
 import com.fs.starfarer.api.util.Misc;
+import data.campaign.econ.boggledTools;
 import data.campaign.econ.conditions.Terraforming_Controller;
 import java.util.*;
 import java.util.List;
@@ -12,6 +13,34 @@ import java.lang.String;
 
 public class boggledTerraformingInitiateProject extends BaseCommandPlugin
 {
+    private static HashMap<String, String> initialiseTriggerProjectToProjectId() {
+        HashMap<String, String> ret = new HashMap<>();
+
+        ret.put(boggledTerraformingDialogPlugin.triggerCancelCurrentProject, boggledTools.noneProjectID);
+
+        ret.put(boggledTerraformingDialogPlugin.triggerAridTypeChange, boggledTools.aridTypeChangeProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerFrozenTypeChange, boggledTools.frozenTypeChangeProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerJungleTypeChange, boggledTools.jungleTypeChangeProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerTerranTypeChange, boggledTools.terranTypeChangeProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerTundraTypeChange, boggledTools.tundraTypeChangeProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerWaterTypeChange, boggledTools.waterTypeChangeProjectID);
+
+        ret.put(boggledTerraformingDialogPlugin.triggerFarmlandResourceImprovement, boggledTools.farmlandResourceImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerOrganicsResourceImprovement, boggledTools.organicsResourceImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerVolatilesResourceImprovement, boggledTools.volatilesResourceImprovementProjectID);
+
+        ret.put(boggledTerraformingDialogPlugin.triggerExtremeWeatherConditionImprovement, boggledTools.extremeWeatherConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerMildClimateConditionImprovement, boggledTools.mildClimateConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerHabitableConditionImprovement, boggledTools.habitableConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerAtmosphereDensityConditionImprovement, boggledTools.atmosphereDensityConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerToxicAtmosphereConditionImprovement, boggledTools.toxicAtmosphereConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerIrradiatedConditionImprovement, boggledTools.irradiatedConditionImprovementProjectID);
+        ret.put(boggledTerraformingDialogPlugin.triggerRemoveAtmosphereConditionImprovement, boggledTools.removeAtmosphereConditionImprovementProjectID);
+
+        return ret;
+    }
+    private static final HashMap<String, String> triggerProjectToProjectId = initialiseTriggerProjectToProjectId();
+
     protected SectorEntityToken entity;
 
     public boggledTerraformingInitiateProject() {}
@@ -30,81 +59,12 @@ public class boggledTerraformingInitiateProject extends BaseCommandPlugin
     {
         if(dialog == null) return false;
 
-        this.entity = dialog.getInteractionTarget();
-        TextPanelAPI text = dialog.getTextPanel();
-
-        MarketAPI market = this.entity.getMarket();
-        PlanetAPI planet = market.getPlanetEntity();
+        MarketAPI market = dialog.getInteractionTarget().getMarket();
         Terraforming_Controller terraformingController = (Terraforming_Controller) market.getCondition("terraforming_controller").getPlugin();
-        String currentProject = terraformingController.getProject();
 
-        if(ruleId.equals("boggledTriggerCancelCurrentProject"))
-        {
-            terraformingController.setProject("None");
-        }
-        else if(ruleId.equals("boggledTriggerAridTypeChange"))
-        {
-            terraformingController.setProject("aridTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerFrozenTypeChange"))
-        {
-            terraformingController.setProject("frozenTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerJungleTypeChange"))
-        {
-            terraformingController.setProject("jungleTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerTerranTypeChange"))
-        {
-            terraformingController.setProject("terranTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerTundraTypeChange"))
-        {
-            terraformingController.setProject("tundraTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerWaterTypeChange"))
-        {
-            terraformingController.setProject("waterTypeChange");
-        }
-        else if(ruleId.equals("boggledTriggerFarmlandResourceImprovement"))
-        {
-            terraformingController.setProject("farmlandResourceImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerOrganicsResourceImprovement"))
-        {
-            terraformingController.setProject("organicsResourceImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerVolatilesResourceImprovement"))
-        {
-            terraformingController.setProject("volatilesResourceImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerExtremeWeatherConditionImprovement"))
-        {
-            terraformingController.setProject("extremeWeatherConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerMildClimateConditionImprovement"))
-        {
-            terraformingController.setProject("mildClimateConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerHabitableConditionImprovement"))
-        {
-            terraformingController.setProject("habitableConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerAtmosphereDensityConditionImprovement"))
-        {
-            terraformingController.setProject("atmosphereDensityConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerToxicAtmosphereConditionImprovement"))
-        {
-            terraformingController.setProject("toxicAtmosphereConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerIrradiatedConditionImprovement"))
-        {
-            terraformingController.setProject("irradiatedConditionImprovement");
-        }
-        else if(ruleId.equals("boggledTriggerRemoveAtmosphereConditionImprovement"))
-        {
-            terraformingController.setProject("removeAtmosphereConditionImprovement");
+        String projectId = triggerProjectToProjectId.get(ruleId);
+        if (projectId != null) {
+            terraformingController.setProject(projectId);
         }
 
         return true;


### PR DESCRIPTION
Hi,
This is interim work for allowing terraforming options to be specified via a rules.csv style file instead of manually doing per mod checks in the code. The primary change is all terraforming and crafting projects are specified via an ID, a tooltip, a set of conditions, and a set of results (currently only used to display the results in the dialogue UI). 

These are implemented via a `TerraformingProject` class which is the top level class for both terraforming and crafting. This stores the project ID, the project tooltip, and a collection of conditions that all have to be satisfied.  The conditions are implemented as a `TerraformingRequirements` class which stores the condition tooltip, whether to invert the condition, and a collection of conditions where only one of them has to be satisfied. Each individual condition is handled by a `TerraformingRequirement` subclass which handles the specifics of this condition.

Using all of this, the terraforming projects are created in `initialiseTerraformingProjects` and the crafting projects in `initialiseCraftingProjects`. This allows simpler expansion or changing of project requirements, and in further work will be specified via a rules.csv style file.

I've done some testing and everything seems to work so far (all projects show up, they start, they finish, they have the expected results, they have the required conditions, and those conditions must be met, but I'm not confident enough to say there's no bugs.

Along the way, I also did some cleanup around other places to remove duplicate code, and replace inline strings with variables. Since strings are used to pass options in a lot of places, any mistyping of the string would lead to plenty of debugging on my part, but a mistyped variable is a compilation error.